### PR TITLE
Fixes so metrics are actually properly included in the profile

### DIFF
--- a/include/data_tree.h
+++ b/include/data_tree.h
@@ -19,8 +19,7 @@ class data_tree {
    public:
     data_tree();
 
-    data_tree(
-        std::map<uint64_t, std::tuple<uint64_t, uint64_t, std::shared_ptr<tree_node>>>& mapping);
+    data_tree(std::map<uint64_t, std::tuple<uint64_t, uint64_t, std::shared_ptr<tree_node>>>& mapping);
 
     tree_node* insert_node(uint64_t function_id, tree_node* parent);
     std::shared_ptr<tree_node> insert_node(uint64_t function_id, std::shared_ptr<tree_node> parent);
@@ -30,12 +29,11 @@ class data_tree {
     void insert_sub_tree(std::shared_ptr<tree_node>& parent, std::shared_ptr<tree_node>& n_node);
 
     /* map< node,parent > */  // mapping darf !NICHT! unordered sein -> Reihenfolge ist wichtig!
-    void serialize_data(
-        std::map<uint64_t, std::pair<uint64_t, uint64_t>>&         mapping,
-        std::deque<std::tuple<uint64_t, uint64_t, FunctionData*>>& f_data,
-        std::deque<std::tuple<uint64_t, uint64_t, MessageData*>>&  m_data,
-        std::deque<std::tuple<uint64_t, uint64_t, CollopData*>>&   c_data,
-        std::deque<std::tuple<uint64_t, uint64_t, uint64_t, MetricData*>>& met_data);
+    void serialize_data(std::map<uint64_t, std::pair<uint64_t, uint64_t>>&         mapping,
+                        std::deque<std::tuple<uint64_t, uint64_t, FunctionData*>>& f_data,
+                        std::deque<std::tuple<uint64_t, uint64_t, MessageData*>>&  m_data,
+                        std::deque<std::tuple<uint64_t, uint64_t, CollopData*>>&   c_data,
+                        std::deque<std::tuple<uint64_t, uint64_t, uint64_t, MetricData*>>& met_data);
 
     /* functionId , node* */
     std::map<uint64_t, std::shared_ptr<tree_node>> root_nodes;
@@ -60,8 +58,7 @@ class tree_node {
    public:
     tree_node(const uint64_t _function_id, tree_node* _parent);
     tree_node(const uint64_t _function_id, const std::shared_ptr<tree_node>& _parent);
-    tree_node(const uint64_t _function_id, const std::shared_ptr<tree_node>& _parent,
-              const uint64_t process_num);
+    tree_node(const uint64_t _function_id, const std::shared_ptr<tree_node>& _parent, const uint64_t process_num);
     tree_node(const uint64_t _function_id);
 
     ~tree_node();
@@ -71,7 +68,7 @@ class tree_node {
     void add_data(const uint64_t location_id, const CollopData& cdata);
     void add_data(const uint64_t location_id, const uint64_t metric_id, const MetricData& metdata);
 
-    //std::shared_ptr<tree_node> parent;
+    // std::shared_ptr<tree_node> parent;
     tree_node* parent;
 
     uint64_t function_id;
@@ -83,11 +80,11 @@ class tree_node {
     /* maps with location id as key -> value = NodeData -> function, p2p or collop */
     std::map<uint64_t, NodeData> node_data;
 
-    std::map<uint64_t, MessageData*> have_message;//TODO raus damit -> sinnlos und fehleranfällig
-    std::map<uint64_t, CollopData*>  have_collop;//TODO raus damit -> sinnlos und fehleranfällig
-//TODO workaround
-        //--->TODO funktion implementieren die aus node_data heraus findet ob collop bzw p2p da ist -> umständlich
-    bool has_p2p = false;
+    std::map<uint64_t, MessageData*> have_message;  // TODO raus damit -> sinnlos und fehleranfällig
+    std::map<uint64_t, CollopData*> have_collop;    // TODO raus damit -> sinnlos und fehleranfällig
+    // TODO workaround
+    //--->TODO funktion implementieren die aus node_data heraus findet ob collop bzw p2p da ist -> umständlich
+    bool has_p2p    = false;
     bool has_collop = false;
 
     uint64_t  last_loc;
@@ -101,8 +98,7 @@ class tree_iter {
         tree_ptr = &_tree;
     };
 
-    tree_iter(tree_node* _rhs_node, data_tree* _rhs_tree)
-        : node_ptr(_rhs_node), tree_ptr(_rhs_tree){};
+    tree_iter(tree_node* _rhs_node, data_tree* _rhs_tree) : node_ptr(_rhs_node), tree_ptr(_rhs_tree){};
 
     tree_iter(const tree_iter& _rhs_it) : node_ptr(_rhs_it.node_ptr), tree_ptr(_rhs_it.tree_ptr){};
 

--- a/include/definitions.h
+++ b/include/definitions.h
@@ -6,13 +6,13 @@
 #ifndef DEFINITIONS_H
 #define DEFINITIONS_H
 
+#include <cassert>
 #include <map>
+#include <memory>
 #include <set>
 #include <string>
 #include <unordered_set>
 #include <vector>
-#include <memory>
-#include <cassert>
 
 #include "main_structs.h"
 
@@ -21,35 +21,35 @@ namespace definitions {
 using paradigm_id_t = uint32_t;
 
 struct Region {
-  std::string   name;
-  paradigm_id_t paradigm_id;
-  uint32_t      source_line;
-  std::string   file_name;
+    std::string   name;
+    paradigm_id_t paradigm_id;
+    uint32_t      source_line;
+    std::string   file_name;
 };
 
 struct Metric {
-  std::string    name;
-  std::string    description;
-  std::string    unit;
-  MetricDataType type; /*OTF2_TYPE_UINT64*/
-  bool           allowed;
+    std::string    name;
+    std::string    description;
+    std::string    unit;
+    MetricDataType type; /*OTF2_TYPE_UINT64*/
+    bool           allowed;
 };
 
 struct Paradigm {
-  std::string    name;
-  // TODO  paradigm class
+    std::string name;
+    // TODO  paradigm class
 };
 
 struct Group {
-  std::string           name;
-  uint16_t              type;
-  paradigm_id_t         paradigm_id;
-  std::vector<uint64_t> members;
+    std::string           name;
+    uint16_t              type;
+    paradigm_id_t         paradigm_id;
+    std::vector<uint64_t> members;
 };
 
-template<typename Id, typename TypeProperties>
+template <typename Id, typename TypeProperties>
 class DefinitionType {
-  public:
+   public:
     using ContainerTypeProps_t = std::map<Id, TypeProperties>;
     using TypeProperties_t     = TypeProperties;
 
@@ -57,25 +57,21 @@ class DefinitionType {
 
     DefinitionType(const ContainerTypeProps_t& props) : all_properties(props) {}
 
-    void add(Id id, const TypeProperties_t& props) {
-      all_properties[id] = props;
-    }
+    void add(Id id, const TypeProperties_t& props) { all_properties[id] = props; }
 
     const TypeProperties_t* get(Id id) const {
-      const auto props_it = all_properties.find(id);
+        const auto props_it = all_properties.find(id);
 
-      if(props_it == all_properties.end())
-        //TODO Error handling
-        return nullptr;
+        if (props_it == all_properties.end())
+            // TODO Error handling
+            return nullptr;
 
-      return &(props_it->second);
+        return &(props_it->second);
     }
 
-    const ContainerTypeProps_t& get_all() const {
-      return all_properties;
-    }
+    const ContainerTypeProps_t& get_all() const { return all_properties; }
 
-  private:
+   private:
     ContainerTypeProps_t all_properties;
 };
 
@@ -96,251 +92,240 @@ enum class SystemClass : uint8_t {
 class SystemIterator;
 
 class SystemTree {
-private:
-  struct SystemData {
-    uint32_t node_id; //TODO ist traceid
-    std::string name;
-    SystemClass class_id;
-    //test
-    uint64_t location_id;
-    uint32_t level;
-  };
+   private:
+    struct SystemData {
+        uint32_t    node_id;  // TODO ist traceid
+        std::string name;
+        SystemClass class_id;
+        // test
+        uint64_t location_id;
+        uint32_t level;
+    };
 
-  struct SystemNode {
-    using Children_t = std::map<uint32_t, std::shared_ptr<SystemNode>>;
+    struct SystemNode {
+        using Children_t = std::map<uint32_t, std::shared_ptr<SystemNode>>;
 
-    SystemNode* parent;
-    Children_t  children; //TODO muss über eigene ids gehen
-    SystemData  data;
+        SystemNode* parent;
+        Children_t  children;  // TODO muss über eigene ids gehen
+        SystemData  data;
 
-    SystemNode(SystemNode* _parent, const Children_t& _children, const SystemData& _data)
-      : parent(_parent), children(_children), data(_data) {}
-  };
+        SystemNode(SystemNode* _parent, const Children_t& _children, const SystemData& _data)
+            : parent(_parent), children(_children), data(_data) {}
+    };
 
-public:
-  using SystemData_t = SystemData;
-  using SystemNode_t = SystemNode;
-  using iterator = SystemIterator;
+   public:
+    using SystemData_t = SystemData;
+    using SystemNode_t = SystemNode;
+    using iterator     = SystemIterator;
 
-  SystemTree() = default;
+    SystemTree() = default;
 
-  void insert_node(const SystemNode_t& node) {
-    auto* parent = node.parent;
+    void insert_node(const SystemNode_t& node) {
+        auto* parent = node.parent;
 
-    if( parent != nullptr )
-      insert_node(node.data.name, node.data.location_id, node.data.class_id,
-          node.parent->data.location_id);
-    else
-      insert_node(node.data.name, node.data.location_id, node.data.class_id,
-          static_cast<uint32_t>(-1));
-  }
-  //void insert_node(SystemTreeNode* aNode);
-  const std::shared_ptr<SystemNode_t> insert_node(std::string name, uint64_t id,
-      SystemClass class_id, uint64_t parent_id) {
-
-    SystemNode* parent = nullptr;
-    if(class_id == SystemClass::LOCATION)
-      parent = location_grps[parent_id];
-    else if(parent_id != static_cast<uint32_t>(-1))
-      parent = system_nodes[parent_id];
-
-    auto new_node = std::make_shared<SystemNode_t>(SystemNode_t(parent, {},{_size, name, class_id, id}));
-
-    if(parent != nullptr) {
-      parent->children.insert(std::make_pair(_size, new_node));
-      new_node->data.level = parent->data.level + 1;
-
-      if(num_nodes_per_level.size() <= new_node->data.level)
-        ++num_nodes_per_level[new_node->data.level];
-      else
-        num_nodes_per_level.push_back(1);
-    } else {
-      new_node->data.level = 0;
-      num_nodes_per_level.push_back(1);
-      root = new_node;
+        if (parent != nullptr)
+            insert_node(node.data.name, node.data.location_id, node.data.class_id, node.parent->data.location_id);
+        else
+            insert_node(node.data.name, node.data.location_id, node.data.class_id, static_cast<uint32_t>(-1));
     }
+    // void insert_node(SystemTreeNode* aNode);
+    const std::shared_ptr<SystemNode_t> insert_node(std::string name, uint64_t id, SystemClass class_id,
+                                                    uint64_t parent_id) {
+        SystemNode* parent = nullptr;
+        if (class_id == SystemClass::LOCATION)
+            parent = location_grps[parent_id];
+        else if (parent_id != static_cast<uint32_t>(-1))
+            parent = system_nodes[parent_id];
 
-    ++_size;
+        auto new_node = std::make_shared<SystemNode_t>(SystemNode_t(parent, {}, {_size, name, class_id, id}));
 
-    if(class_id == SystemClass::LOCATION) {
-      locations.insert(std::make_pair(id, new_node.get()));
-      return new_node;
-    }
+        if (parent != nullptr) {
+            parent->children.insert(std::make_pair(_size, new_node));
+            new_node->data.level = parent->data.level + 1;
 
-    if(class_id == SystemClass::LOCATION_GROUP)
-      location_grps.push_back(new_node.get());
-    else
-      system_nodes.push_back(new_node.get());
-
-    return new_node;
-  }
-
-
-  std::pair<uint8_t, std::unique_ptr<SystemTree>> summarize(const SystemTree& sys_tree,
-    uint64_t limit) {
-
-    //find the level where the count of nodes is bigger then the set limit
-    bool do_it = false;
-    size_t level = 0;
-    for( level = 0; level < num_nodes_per_level.size(); ++level ) {
-      if(num_nodes_per_level[level] > limit){
-        if( level > 1 ) {
-          if( num_nodes_per_level[level-1] > 1 ) {
-            do_it = true;
-            break;
-          }
+            if (num_nodes_per_level.size() <= new_node->data.level)
+                ++num_nodes_per_level[new_node->data.level];
+            else
+                num_nodes_per_level.push_back(1);
+        } else {
+            new_node->data.level = 0;
+            num_nodes_per_level.push_back(1);
+            root = new_node;
         }
-        //TODO überspringt effektiv den fall wenn (level - 2) > 1 ist, etc.
-        //summarize can't be done -> (level - 1) has < 2 elements
-        return std::make_pair(2,nullptr);
-      }
+
+        ++_size;
+
+        if (class_id == SystemClass::LOCATION) {
+            locations.insert(std::make_pair(id, new_node.get()));
+            return new_node;
+        }
+
+        if (class_id == SystemClass::LOCATION_GROUP)
+            location_grps.push_back(new_node.get());
+        else
+            system_nodes.push_back(new_node.get());
+
+        return new_node;
     }
-    if(do_it)
-      return std::make_pair(1, std::unique_ptr<SystemTree>(copy_reduced(sys_tree, level)));
 
-    return std::make_pair(0,nullptr);
-  }
+    std::pair<uint8_t, std::unique_ptr<SystemTree>> summarize(const SystemTree& sys_tree, uint64_t limit) {
+        // find the level where the count of nodes is bigger then the set limit
+        bool   do_it = false;
+        size_t level = 0;
+        for (level = 0; level < num_nodes_per_level.size(); ++level) {
+            if (num_nodes_per_level[level] > limit) {
+                if (level > 1) {
+                    if (num_nodes_per_level[level - 1] > 1) {
+                        do_it = true;
+                        break;
+                    }
+                }
+                // TODO überspringt effektiv den fall wenn (level - 2) > 1 ist, etc.
+                // summarize can't be done -> (level - 1) has < 2 elements
+                return std::make_pair(2, nullptr);
+            }
+        }
+        if (do_it)
+            return std::make_pair(1, std::unique_ptr<SystemTree>(copy_reduced(sys_tree, level)));
 
-  const std::shared_ptr<SystemNode_t> get_root() const { return root;}
+        return std::make_pair(0, nullptr);
+    }
 
-  const size_t num_level() const { return num_nodes_per_level.size(); }
+    const std::shared_ptr<SystemNode_t> get_root() const { return root; }
 
-  const std::vector<uint32_t>&  all_level() const { return num_nodes_per_level; }
+    const size_t num_level() const { return num_nodes_per_level.size(); }
 
-  const uint32_t size() const {return _size;}
+    const std::vector<uint32_t>& all_level() const { return num_nodes_per_level; }
 
-  SystemNode_t* location(size_t location_id) {
-    auto it = locations.find(location_id);
-    if(it != locations.end())
-      return it->second;
+    const uint32_t size() const { return _size; }
 
-    return nullptr;
-  }
+    SystemNode_t* location(size_t location_id) {
+        auto it = locations.find(location_id);
+        if (it != locations.end())
+            return it->second;
 
-  iterator begin() const;
+        return nullptr;
+    }
 
-  iterator end() const;
+    iterator begin() const;
 
-private:
-  SystemTree* copy_reduced(const SystemTree& sys_tree, uint32_t level );
+    iterator end() const;
 
-private:
-  std::shared_ptr<SystemNode_t>     root;
-  std::vector<SystemNode_t*>        system_nodes{};
-  std::vector<SystemNode_t*>        location_grps{};
-  std::map<uint64_t, SystemNode_t*> locations{};
-  uint32_t                          _size = 0;
-  //test
-  std::vector<uint32_t>             num_nodes_per_level;
+   private:
+    SystemTree* copy_reduced(const SystemTree& sys_tree, uint32_t level);
+
+   private:
+    std::shared_ptr<SystemNode_t> root;
+    std::vector<SystemNode_t*>    system_nodes{};
+    std::vector<SystemNode_t*>    location_grps{};
+    std::map<uint64_t, SystemNode_t*> locations{};
+    uint32_t _size = 0;
+    // test
+    std::vector<uint32_t> num_nodes_per_level;
 };
 
-//TODO iterator traits
+// TODO iterator traits
 class SystemIterator {
-private:
-  using SystemData_t = typename SystemTree::SystemData_t;
-  using SystemNode_t = typename SystemTree::SystemNode_t;
+   private:
+    using SystemData_t = typename SystemTree::SystemData_t;
+    using SystemNode_t = typename SystemTree::SystemNode_t;
 
-public:
-  SystemIterator(const std::shared_ptr<SystemNode_t>& root)
-    : current_ptr(root.get()), root_ptr(root) {
-    assert(root.get() != nullptr);
-  }
-
-  SystemIterator(const std::shared_ptr<SystemNode_t>& root, SystemNode_t* node)
-    : current_ptr(node), root_ptr(root) {
-    assert(root.get() != nullptr);
-  }
-
-  SystemIterator() = default;
-
-  SystemIterator(const SystemIterator& rhs_iter) = default;
-
-  SystemIterator& operator= (const SystemIterator& rhs_iter) {
-    current_ptr = rhs_iter.current_ptr;
-    root_ptr = rhs_iter.root_ptr;
-
-    return *this;
-  }
-
-  SystemNode_t& operator*() {
-    assert(current_ptr != nullptr );
-    return *current_ptr;
-  }
-
-  SystemNode_t* operator->() {
-    assert(current_ptr != nullptr );
-    return current_ptr;
-  }
-
-  SystemIterator& operator++() {
-    assert(current_ptr != nullptr );
-
-    if(!current_ptr->children.empty())
-      current_ptr = current_ptr->children.begin()->second.get();
-    else {
-      while(true) {
-        if(current_ptr->parent != nullptr) {
-          auto child_it = current_ptr->parent->children.find(current_ptr->data.node_id);
-          ++child_it;
-
-          if(child_it == current_ptr->parent->children.end()){
-            current_ptr = current_ptr->parent;
-            continue;
-          }
-
-          current_ptr = child_it->second.get();
-
-          return *this;
-        }
-
-        //got back to root -> end of iteration
-        current_ptr = nullptr;
-        break;
-      }
+   public:
+    SystemIterator(const std::shared_ptr<SystemNode_t>& root) : current_ptr(root.get()), root_ptr(root) {
+        assert(root.get() != nullptr);
     }
 
-    return *this;
-  }
+    SystemIterator(const std::shared_ptr<SystemNode_t>& root, SystemNode_t* node) : current_ptr(node), root_ptr(root) {
+        assert(root.get() != nullptr);
+    }
 
-  SystemIterator operator++(int) {
-    SystemIterator it(*this);
-    ++*this;
+    SystemIterator() = default;
 
-    return it;
-  }
+    SystemIterator(const SystemIterator& rhs_iter) = default;
 
-  bool operator==(const SystemIterator& rhs_it) {
-    return ((current_ptr == rhs_it.current_ptr) && (root_ptr == rhs_it.root_ptr));
-  }
-  bool operator!=(const SystemIterator& rhs_it){
-    return ((current_ptr != rhs_it.current_ptr) || (root_ptr != rhs_it.root_ptr));
-  }
+    SystemIterator& operator=(const SystemIterator& rhs_iter) {
+        current_ptr = rhs_iter.current_ptr;
+        root_ptr    = rhs_iter.root_ptr;
 
-private:
-  SystemNode_t*                 current_ptr;
-  std::shared_ptr<SystemNode_t> root_ptr;
+        return *this;
+    }
 
+    SystemNode_t& operator*() {
+        assert(current_ptr != nullptr);
+        return *current_ptr;
+    }
+
+    SystemNode_t* operator->() {
+        assert(current_ptr != nullptr);
+        return current_ptr;
+    }
+
+    SystemIterator& operator++() {
+        assert(current_ptr != nullptr);
+
+        if (!current_ptr->children.empty())
+            current_ptr = current_ptr->children.begin()->second.get();
+        else {
+            while (true) {
+                if (current_ptr->parent != nullptr) {
+                    auto child_it = current_ptr->parent->children.find(current_ptr->data.node_id);
+                    ++child_it;
+
+                    if (child_it == current_ptr->parent->children.end()) {
+                        current_ptr = current_ptr->parent;
+                        continue;
+                    }
+
+                    current_ptr = child_it->second.get();
+
+                    return *this;
+                }
+
+                // got back to root -> end of iteration
+                current_ptr = nullptr;
+                break;
+            }
+        }
+
+        return *this;
+    }
+
+    SystemIterator operator++(int) {
+        SystemIterator it(*this);
+        ++*this;
+
+        return it;
+    }
+
+    bool operator==(const SystemIterator& rhs_it) {
+        return ((current_ptr == rhs_it.current_ptr) && (root_ptr == rhs_it.root_ptr));
+    }
+    bool operator!=(const SystemIterator& rhs_it) {
+        return ((current_ptr != rhs_it.current_ptr) || (root_ptr != rhs_it.root_ptr));
+    }
+
+   private:
+    SystemNode_t*                 current_ptr;
+    std::shared_ptr<SystemNode_t> root_ptr;
 };
 
 struct Definitions {
-  DefinitionType<uint64_t, Region>            regions;
-  DefinitionType<uint64_t, Metric>            metrics;
-  DefinitionType<paradigm_id_t, Paradigm>     paradigms;
-  DefinitionType<uint64_t, Group>             groups;
-  SystemTree                                  system_tree{};
+    DefinitionType<uint64_t, Region>        regions;
+    DefinitionType<uint64_t, Metric>        metrics;
+    DefinitionType<paradigm_id_t, Paradigm> paradigms;
+    DefinitionType<uint64_t, Group>         groups;
+    SystemTree system_tree{};
 };
-} // namespace definitions
-
+}  // namespace definitions
 
 struct meta_data {
-    std::map<uint64_t, uint64_t>              communicators;
+    std::map<uint64_t, uint64_t> communicators;
 
     std::map<uint64_t, std::string> processIdToName;
 
     std::map<uint64_t, std::string> metricIdToName;
 
-
-    //std::map<uint64_t, metric_definition> metricIdToDef;
+    // std::map<uint64_t, metric_definition> metricIdToDef;
 
     // class_id, pair< number_in_class, metric_id >
     std::map<uint64_t, std::map<uint64_t, uint64_t>> metricClassToMetric;
@@ -356,8 +341,7 @@ struct meta_data {
 
 #endif
 
-    meta_data(uint32_t my_rank = 0, uint32_t num_ranks = 1)
-        : myRank(my_rank), numRanks(num_ranks), timerResolution(0) {
+    meta_data(uint32_t my_rank = 0, uint32_t num_ranks = 1) : myRank(my_rank), numRanks(num_ranks), timerResolution(0) {
 #ifdef OTFPROFILE_MPI
 
         packBufferSize = 0;
@@ -369,7 +353,7 @@ struct meta_data {
     ~meta_data() {
 #ifdef OTFPROFILE_MPI
 
-       freePackBuffer();
+        freePackBuffer();
 
 #endif
     }
@@ -398,4 +382,4 @@ struct meta_data {
 #endif /* OTFPROFILE_MPI */
 };
 
-#endif // DEFINITIONS_H
+#endif  // DEFINITIONS_H

--- a/include/main_structs.h
+++ b/include/main_structs.h
@@ -3,7 +3,6 @@
  Authors: Maximillian Neumann, Denis Hünich, Jens Doleschal
 */
 
-
 #ifndef MAIN_STRUCTS_H
 #define MAIN_STRUCTS_H
 
@@ -21,7 +20,8 @@ enum class MetricDataType : uint8_t {
 //  --> benötigt wird noch eine sinnvolle strategie wie man mit verschiedenen Arten von Metriken umgehen kann
 //      --> problematisch dabei ist OTF da die Einschränkung im Sinne von Synchronität etc. nicht gibt
 //  --> die metric-callbacks sind Fehlerintollerant was oft zu segmentation faults oder falschen Daten führen kann
-//  --> für nicht synchrone metrics w#re ex möglich zusätzliche Conatainer zu erstellen => Nutzung abhängig von Ausgabe (gleiches gilt für andere asynchrone Daten z.B. rma)
+//  --> für nicht synchrone metrics w#re ex möglich zusätzliche Conatainer zu erstellen => Nutzung abhängig von Ausgabe
+//  (gleiches gilt für andere asynchrone Daten z.B. rma)
 
 struct MetricData {
     MetricDataType type;
@@ -181,11 +181,14 @@ struct FunctionData {
     }
 };
 
-//TODO MessageData und CollopData sind prinzipiell ziemlich ähnlich
+// TODO MessageData und CollopData sind prinzipiell ziemlich ähnlich
 // unterschiedlich können sie erst werden wenn eine Art Messagematching implementiert wird.
 //  -> selbst dann kann ein struct beides abbilden sofern man die Matchinginformationen nicht anbindet
-//  ==> eine Art MessageSummary-Container wäre denkbar in dem abgelegt wird welches Prozess mit wem wie viel kommuniziert hat
-//      -> für collop wäre der Aufwand höher (zumindest in OTF2) da die Kommunikatoren berücksichtigt werden müssen, während man bei den P2P-Daten die Kommunikatoren ignorieren kann (so lang man nicht genau Kommunikatoren basierende Daten angelegen will)
+//  ==> eine Art MessageSummary-Container wäre denkbar in dem abgelegt wird welches Prozess mit wem wie viel
+//  kommuniziert hat
+//      -> für collop wäre der Aufwand höher (zumindest in OTF2) da die Kommunikatoren berücksichtigt werden müssen,
+//      während man bei den P2P-Daten die Kommunikatoren ignorieren kann (so lang man nicht genau Kommunikatoren
+//      basierende Daten angelegen will)
 
 struct MessageData {
     uint64_t count_send;
@@ -218,7 +221,7 @@ struct CollopData {
         return *this;
     }
 };
-//TODO momentan ungenutzt --> sehr ähnlich zu message und collop
+// TODO momentan ungenutzt --> sehr ähnlich zu message und collop
 struct RmaData {
     uint64_t rma_put_cnt;
     uint64_t rma_get_cnt;

--- a/include/otf-profiler.h
+++ b/include/otf-profiler.h
@@ -8,8 +8,8 @@
 
 #include <string>
 
-#include "otf-profiler-config.h" 
 #include "all_data.h"
+#include "otf-profiler-config.h"
 
 /* name of program executable */
 extern const std::string ExeName;

--- a/include/reader/OTF2Reader.h
+++ b/include/reader/OTF2Reader.h
@@ -10,40 +10,35 @@
 #include "tracereader.h"
 
 class StringIdentifier {
-public:
-  template<typename... Refs>
-  using Result_t = std::array<std::string*,sizeof...(Refs)>;
+   public:
+    template <typename... Refs>
+    using Result_t = std::array<std::string*, sizeof...(Refs)>;
 
-public:
-  StringIdentifier() {
-    string_definitions[OTF2_UNDEFINED_STRING] = "";
-  }
+   public:
+    StringIdentifier() { string_definitions[OTF2_UNDEFINED_STRING] = ""; }
 
-  void add(OTF2_StringRef ref, const char* string_def) {
-    string_definitions[ref] = string_def;
-  }
+    void add(OTF2_StringRef ref, const char* string_def) { string_definitions[ref] = string_def; }
 
-  template<typename... Refs>
-  const std::pair<Result_t<Refs...>, OTF2_CallbackCode> get(Refs... refs) {
+    template <typename... Refs>
+    const std::pair<Result_t<Refs...>, OTF2_CallbackCode> get(Refs... refs) {
+        auto              pos = 0;
+        Result_t<Refs...> result{};
 
-    auto pos = 0;
-    Result_t<Refs...> result{};
+        for (auto ref : {refs...}) {
+            auto it = string_definitions.find(ref);
+            if (it != string_definitions.end())
+                result[pos] = &it->second;
+            else
+                return std::make_pair(result, OTF2_CALLBACK_INTERRUPT);
 
-    for(auto ref : {refs...}) {
-      auto it = string_definitions.find(ref);
-      if(it != string_definitions.end())
-        result[pos] = &it->second;
-      else
-        return std::make_pair(result, OTF2_CALLBACK_INTERRUPT);
+            ++pos;
+        }
 
-      ++pos;
+        return std::make_pair(result, OTF2_CALLBACK_SUCCESS);
     }
 
-    return std::make_pair(result, OTF2_CALLBACK_SUCCESS);
-  }
-
-private:
-  std::map<OTF2_StringRef, std::string> string_definitions;
+   private:
+    std::map<OTF2_StringRef, std::string> string_definitions;
 };
 
 class OTF2Reader : public TraceReader {
@@ -86,8 +81,7 @@ class OTF2Reader : public TraceReader {
      */
     static inline OTF2_CallbackCode handle_enter(OTF2_LocationRef locationID, OTF2_TimeStamp time,
                                                  uint64_t eventPosition, void* userData,
-                                                 OTF2_AttributeList* attributeList,
-                                                 OTF2_RegionRef      region);
+                                                 OTF2_AttributeList* attributeList, OTF2_RegionRef region);
 
     /** @brief Callback for the Leave event record.
      *
@@ -107,8 +101,7 @@ class OTF2Reader : public TraceReader {
      */
     static inline OTF2_CallbackCode handle_leave(OTF2_LocationRef locationID, OTF2_TimeStamp time,
                                                  uint64_t eventPosition, void* userData,
-                                                 OTF2_AttributeList* attributeList,
-                                                 OTF2_RegionRef      region);
+                                                 OTF2_AttributeList* attributeList, OTF2_RegionRef region);
 
     /** @brief Callback for the MpiSend event record.
      *
@@ -131,12 +124,10 @@ class OTF2Reader : public TraceReader {
      *
      *  @return @eref{OTF2_CALLBACK_SUCCESS} or @eref{OTF2_CALLBACK_INTERRUPT}.
      */
-    static inline OTF2_CallbackCode handle_mpi_send(OTF2_LocationRef locationID,
-                                                    OTF2_TimeStamp time, uint64_t eventPosition,
-                                                    void*               userData,
-                                                    OTF2_AttributeList* attributeList,
-                                                    uint32_t receiver, OTF2_CommRef communicator,
-                                                    uint32_t msgTag, uint64_t msgLength);
+    static inline OTF2_CallbackCode handle_mpi_send(OTF2_LocationRef locationID, OTF2_TimeStamp time,
+                                                    uint64_t eventPosition, void* userData,
+                                                    OTF2_AttributeList* attributeList, uint32_t receiver,
+                                                    OTF2_CommRef communicator, uint32_t msgTag, uint64_t msgLength);
 
     /** @brief Callback for the MpiIsend event record.
      *
@@ -160,10 +151,11 @@ class OTF2Reader : public TraceReader {
      *
      *  @return @eref{OTF2_CALLBACK_SUCCESS} or @eref{OTF2_CALLBACK_INTERRUPT}.
      */
-    static inline OTF2_CallbackCode handle_mpi_isend(
-        OTF2_LocationRef locationID, OTF2_TimeStamp time, uint64_t eventPosition, void* userData,
-        OTF2_AttributeList* attributeList, uint32_t receiver, OTF2_CommRef communicator,
-        uint32_t msgTag, uint64_t msgLength, uint64_t requestID);
+    static inline OTF2_CallbackCode handle_mpi_isend(OTF2_LocationRef locationID, OTF2_TimeStamp time,
+                                                     uint64_t eventPosition, void* userData,
+                                                     OTF2_AttributeList* attributeList, uint32_t receiver,
+                                                     OTF2_CommRef communicator, uint32_t msgTag, uint64_t msgLength,
+                                                     uint64_t requestID);
 
     /** @brief Callback for the MpiIsendComplete event record.
      *
@@ -181,7 +173,7 @@ class OTF2Reader : public TraceReader {
      *
      *  @return @eref{OTF2_CALLBACK_SUCCESS} or @eref{OTF2_CALLBACK_INTERRUPT}.
      */
-//TODO nicht verwendet
+    // TODO nicht verwendet
     /*
     static inline OTF2_CallbackCode handle_mpi_isend_complete(
         OTF2_LocationRef locationID, OTF2_TimeStamp time, uint64_t eventPosition, void* userData,
@@ -209,12 +201,10 @@ class OTF2Reader : public TraceReader {
      *
      *  @return @eref{OTF2_CALLBACK_SUCCESS} or @eref{OTF2_CALLBACK_INTERRUPT}.
      */
-    static inline OTF2_CallbackCode handle_mpi_recv(OTF2_LocationRef locationID,
-                                                    OTF2_TimeStamp time, uint64_t eventPosition,
-                                                    void*               userData,
-                                                    OTF2_AttributeList* attributeList,
-                                                    uint32_t sender, OTF2_CommRef communicator,
-                                                    uint32_t msgTag, uint64_t msgLength);
+    static inline OTF2_CallbackCode handle_mpi_recv(OTF2_LocationRef locationID, OTF2_TimeStamp time,
+                                                    uint64_t eventPosition, void* userData,
+                                                    OTF2_AttributeList* attributeList, uint32_t sender,
+                                                    OTF2_CommRef communicator, uint32_t msgTag, uint64_t msgLength);
 
     /** @brief Callback for the MpiIrecvRequest event record.
      *
@@ -257,10 +247,11 @@ class OTF2Reader : public TraceReader {
      *
      *  @return @eref{OTF2_CALLBACK_SUCCESS} or @eref{OTF2_CALLBACK_INTERRUPT}.
      */
-    static inline OTF2_CallbackCode handle_mpi_irecv(
-        OTF2_LocationRef locationID, OTF2_TimeStamp time, uint64_t eventPosition, void* userData,
-        OTF2_AttributeList* attributeList, uint32_t sender, OTF2_CommRef communicator,
-        uint32_t msgTag, uint64_t msgLength, uint64_t requestID);
+    static inline OTF2_CallbackCode handle_mpi_irecv(OTF2_LocationRef locationID, OTF2_TimeStamp time,
+                                                     uint64_t eventPosition, void* userData,
+                                                     OTF2_AttributeList* attributeList, uint32_t sender,
+                                                     OTF2_CommRef communicator, uint32_t msgTag, uint64_t msgLength,
+                                                     uint64_t requestID);
 
     /** @brief Callback for the BufferFlush event record.
      *
@@ -275,7 +266,7 @@ class OTF2Reader : public TraceReader {
      *
      *  @return @eref{OTF2_CALLBACK_SUCCESS} or @eref{OTF2_CALLBACK_INTERRUPT}.
      */
-//TODO nicht verwendet
+    // TODO nicht verwendet
     /*
     static inline OTF2_CallbackCode handle_buffer_flush(OTF2_LocationRef locationID,
                                                         OTF2_TimeStamp time, void* userData,
@@ -347,10 +338,11 @@ class OTF2Reader : public TraceReader {
      *
      *  @return @eref{OTF2_CALLBACK_SUCCESS} or @eref{OTF2_CALLBACK_INTERRUPT}.
      */
-    static inline OTF2_CallbackCode handle_mpi_collective_end(
-        OTF2_LocationRef locationID, OTF2_TimeStamp time, uint64_t eventPosition, void* userData,
-        OTF2_AttributeList* attributeList, OTF2_CollectiveOp type, OTF2_CommRef communicator,
-        uint32_t root, uint64_t sizeSent, uint64_t sizeReceived);
+    static inline OTF2_CallbackCode handle_mpi_collective_end(OTF2_LocationRef locationID, OTF2_TimeStamp time,
+                                                              uint64_t eventPosition, void* userData,
+                                                              OTF2_AttributeList* attributeList, OTF2_CollectiveOp type,
+                                                              OTF2_CommRef communicator, uint32_t root,
+                                                              uint64_t sizeSent, uint64_t sizeReceived);
 
     /** @brief Callback for the OmpFork event record.
      *
@@ -364,7 +356,7 @@ class OTF2Reader : public TraceReader {
      *
      *  @return @eref{OTF2_CALLBACK_SUCCESS} or @eref{OTF2_CALLBACK_INTERRUPT}.
      */
-//TODO nicht verwendet
+    // TODO nicht verwendet
     /*
     static inline OTF2_CallbackCode handle_omp_fork(OTF2_LocationRef locationID,
                                                     OTF2_TimeStamp time, void* userData,
@@ -384,7 +376,7 @@ class OTF2Reader : public TraceReader {
      *
      *  @return @eref{OTF2_CALLBACK_SUCCESS} or @eref{OTF2_CALLBACK_INTERRUPT}.
      */
-    //TODO nicht verwendet
+    // TODO nicht verwendet
     /*
     static inline OTF2_CallbackCode handle_omp_join(OTF2_LocationRef locationID,
                                                     OTF2_TimeStamp time, void* userData,
@@ -409,11 +401,9 @@ class OTF2Reader : public TraceReader {
      *
      *  @return @eref{OTF2_CALLBACK_SUCCESS} or @eref{OTF2_CALLBACK_INTERRUPT}.
      */
-    static inline OTF2_CallbackCode handle_omp_acquire_lock(OTF2_LocationRef locationID,
-                                                            OTF2_TimeStamp time, void* userData,
-                                                            OTF2_AttributeList* attributeList,
-                                                            uint32_t            lockID,
-                                                            uint32_t            acquisitionOrder);
+    static inline OTF2_CallbackCode handle_omp_acquire_lock(OTF2_LocationRef locationID, OTF2_TimeStamp time,
+                                                            void* userData, OTF2_AttributeList* attributeList,
+                                                            uint32_t lockID, uint32_t acquisitionOrder);
 
     /** @brief Callback for the OmpReleaseLock event record.
      *
@@ -431,11 +421,9 @@ class OTF2Reader : public TraceReader {
      *
      *  @return @eref{OTF2_CALLBACK_SUCCESS} or @eref{OTF2_CALLBACK_INTERRUPT}.
      */
-    static inline OTF2_CallbackCode handle_omp_release_lock(OTF2_LocationRef locationID,
-                                                            OTF2_TimeStamp time, void* userData,
-                                                            OTF2_AttributeList* attributeList,
-                                                            uint32_t            lockID,
-                                                            uint32_t            acquisitionOrder);
+    static inline OTF2_CallbackCode handle_omp_release_lock(OTF2_LocationRef locationID, OTF2_TimeStamp time,
+                                                            void* userData, OTF2_AttributeList* attributeList,
+                                                            uint32_t lockID, uint32_t acquisitionOrder);
 
     /** @brief Callback for the OmpTaskCreate event record.
      *
@@ -450,10 +438,9 @@ class OTF2Reader : public TraceReader {
      *
      *  @return @eref{OTF2_CALLBACK_SUCCESS} or @eref{OTF2_CALLBACK_INTERRUPT}.
      */
-    static inline OTF2_CallbackCode handle_omp_task_create(OTF2_LocationRef locationID,
-                                                           OTF2_TimeStamp time, void* userData,
-                                                           OTF2_AttributeList* attributeList,
-                                                           uint64_t            taskID);
+    static inline OTF2_CallbackCode handle_omp_task_create(OTF2_LocationRef locationID, OTF2_TimeStamp time,
+                                                           void* userData, OTF2_AttributeList* attributeList,
+                                                           uint64_t taskID);
 
     /** @brief Callback for the OmpTaskSwitch event record.
      *
@@ -470,10 +457,9 @@ class OTF2Reader : public TraceReader {
      *
      *  @return @eref{OTF2_CALLBACK_SUCCESS} or @eref{OTF2_CALLBACK_INTERRUPT}.
      */
-    static inline OTF2_CallbackCode handle_omp_task_switch(OTF2_LocationRef locationID,
-                                                           OTF2_TimeStamp time, void* userData,
-                                                           OTF2_AttributeList* attributeList,
-                                                           uint64_t            taskID);
+    static inline OTF2_CallbackCode handle_omp_task_switch(OTF2_LocationRef locationID, OTF2_TimeStamp time,
+                                                           void* userData, OTF2_AttributeList* attributeList,
+                                                           uint64_t taskID);
 
     /** @brief Callback for the OmpTaskComplete event record.
      *
@@ -488,10 +474,9 @@ class OTF2Reader : public TraceReader {
      *
      *  @return @eref{OTF2_CALLBACK_SUCCESS} or @eref{OTF2_CALLBACK_INTERRUPT}.
      */
-    static inline OTF2_CallbackCode handle_omp_task_complete(OTF2_LocationRef locationID,
-                                                             OTF2_TimeStamp time, void* userData,
-                                                             OTF2_AttributeList* attributeList,
-                                                             uint64_t            taskID);
+    static inline OTF2_CallbackCode handle_omp_task_complete(OTF2_LocationRef locationID, OTF2_TimeStamp time,
+                                                             void* userData, OTF2_AttributeList* attributeList,
+                                                             uint64_t taskID);
 
     /** @brief Callback for the Metric event record.
      *
@@ -518,9 +503,8 @@ class OTF2Reader : public TraceReader {
      */
     static inline OTF2_CallbackCode handle_metric(OTF2_LocationRef locationID, OTF2_TimeStamp time,
                                                   uint64_t eventPosition, void* userData,
-                                                  OTF2_AttributeList* attributeList,
-                                                  OTF2_MetricRef metric, uint8_t numberOfMetrics,
-                                                  const OTF2_Type*        typeIDs,
+                                                  OTF2_AttributeList* attributeList, OTF2_MetricRef metric,
+                                                  uint8_t numberOfMetrics, const OTF2_Type* typeIDs,
                                                   const OTF2_MetricValue* metricValues);
 
     // TODO comments
@@ -577,22 +561,21 @@ class OTF2Reader : public TraceReader {
     /* ************************************************************** */
 
     // TODO nicht verwendet
-    static inline OTF2_CallbackCode handle_def_attribute(void* userData, OTF2_AttributeRef self,
-                                                         OTF2_StringRef name,
-                                                         OTF2_StringRef description,
-                                                         OTF2_Type      type);
+    static inline OTF2_CallbackCode handle_def_attribute(void* userData, OTF2_AttributeRef self, OTF2_StringRef name,
+                                                         OTF2_StringRef description, OTF2_Type type);
 
     // TODO comment
-    static inline OTF2_CallbackCode handle_def_metric_class(
-        void* userData, OTF2_MetricRef self, uint8_t numberOfMetrics,
-        const OTF2_MetricMemberRef* metricMembers, OTF2_MetricOccurrence metricOccurence,
-        OTF2_RecorderKind recorderKind);
+    static inline OTF2_CallbackCode handle_def_metric_class(void* userData, OTF2_MetricRef self,
+                                                            uint8_t                     numberOfMetrics,
+                                                            const OTF2_MetricMemberRef* metricMembers,
+                                                            OTF2_MetricOccurrence       metricOccurence,
+                                                            OTF2_RecorderKind           recorderKind);
 
     // TODO comment
-    static inline OTF2_CallbackCode handle_def_metrics(
-        void* userData, OTF2_MetricMemberRef self, OTF2_StringRef name, OTF2_StringRef description,
-        OTF2_MetricType metricType, OTF2_MetricMode metricMode, OTF2_Type valueType, OTF2_Base base,
-        int64_t exponent, OTF2_StringRef uint);
+    static inline OTF2_CallbackCode handle_def_metrics(void* userData, OTF2_MetricMemberRef self, OTF2_StringRef name,
+                                                       OTF2_StringRef description, OTF2_MetricType metricType,
+                                                       OTF2_MetricMode metricMode, OTF2_Type valueType, OTF2_Base base,
+                                                       int64_t exponent, OTF2_StringRef uint);
 
     /** @brief Function pointer definition for the callback which is
      *         triggered by a ClockProperties definition record.
@@ -610,10 +593,8 @@ class OTF2Reader : public TraceReader {
      *
      * @return @eref{OTF2_CALLBACK_SUCCESS} or @eref{OTF2_CALLBACK_INTERRUPT}.
      */
-    static inline OTF2_CallbackCode handle_def_clock_properties(void*    userData,
-                                                                uint64_t timerResolution,
-                                                                uint64_t globalOffset,
-                                                                uint64_t traceLength);
+    static inline OTF2_CallbackCode handle_def_clock_properties(void* userData, uint64_t timerResolution,
+                                                                uint64_t globalOffset, uint64_t traceLength);
 
     /** @brief Callback which is triggered by LocationGroup definition record.
      *
@@ -628,9 +609,10 @@ class OTF2Reader : public TraceReader {
      *  @return @eref{OTF2_CALLBACK_SUCCESS} or @eref{OTF2_CALLBACK_INTERRUPT}.
      */
 
-    static inline OTF2_CallbackCode handle_def_location_group(
-        void* userData, OTF2_LocationGroupRef groupIdentifier, OTF2_StringRef name,
-        OTF2_LocationGroupType locationGroupType, OTF2_SystemTreeNodeRef systemTreeParent);
+    static inline OTF2_CallbackCode handle_def_location_group(void* userData, OTF2_LocationGroupRef groupIdentifier,
+                                                              OTF2_StringRef         name,
+                                                              OTF2_LocationGroupType locationGroupType,
+                                                              OTF2_SystemTreeNodeRef systemTreeParent);
 
     /** @brief Callback which is triggered by a Location definition record.
      *
@@ -646,12 +628,9 @@ class OTF2Reader : public TraceReader {
      *
      *  @return @eref{OTF2_CALLBACK_SUCCESS} or @eref{OTF2_CALLBACK_INTERRUPT}.
      */
-    static inline OTF2_CallbackCode handle_def_location(void*                 userData,
-                                                        OTF2_LocationRef      locationIdentifier,
-                                                        OTF2_StringRef        name,
-                                                        OTF2_LocationType     locationType,
-                                                        uint64_t              numberOfEvents,
-                                                        OTF2_LocationGroupRef locationGroup);
+    static inline OTF2_CallbackCode handle_def_location(void* userData, OTF2_LocationRef locationIdentifier,
+                                                        OTF2_StringRef name, OTF2_LocationType locationType,
+                                                        uint64_t numberOfEvents, OTF2_LocationGroupRef locationGroup);
 
     /** @brief Callback which is triggered by Group definition record.
      *
@@ -668,11 +647,9 @@ class OTF2Reader : public TraceReader {
      *
      *  @return @eref{OTF2_CALLBACK_SUCCESS} or @eref{OTF2_CALLBACK_INTERRUPT}.
      */
-    static inline OTF2_CallbackCode handle_def_group(void* userData, OTF2_GroupRef groupIdentifier,
-                                                     OTF2_StringRef name, OTF2_GroupType groupType,
-                                                     OTF2_Paradigm   paradigm,
-                                                     OTF2_GroupFlag  groupFlags,
-                                                     uint32_t        numberOfMembers,
+    static inline OTF2_CallbackCode handle_def_group(void* userData, OTF2_GroupRef groupIdentifier, OTF2_StringRef name,
+                                                     OTF2_GroupType groupType, OTF2_Paradigm paradigm,
+                                                     OTF2_GroupFlag groupFlags, uint32_t numberOfMembers,
                                                      const uint64_t* members);
 
     /** @brief Callback which is triggered by a Region definition record.
@@ -698,11 +675,12 @@ class OTF2Reader : public TraceReader {
      *
      *  @return @eref{OTF2_CALLBACK_SUCCESS} or @eref{OTF2_CALLBACK_INTERRUPT}.
      */
-    static inline OTF2_CallbackCode handle_def_region(
-        void* userData, OTF2_RegionRef regionIdentifier, OTF2_StringRef name,
-        OTF2_StringRef canonicalName, OTF2_StringRef description, OTF2_RegionRole regionRole,
-        OTF2_Paradigm paradigm, OTF2_RegionFlag regionFlags, OTF2_StringRef sourceFile,
-        uint32_t beginLineNumber, uint32_t endLineNumber);
+    static inline OTF2_CallbackCode handle_def_region(void* userData, OTF2_RegionRef regionIdentifier,
+                                                      OTF2_StringRef name, OTF2_StringRef canonicalName,
+                                                      OTF2_StringRef description, OTF2_RegionRole regionRole,
+                                                      OTF2_Paradigm paradigm, OTF2_RegionFlag regionFlags,
+                                                      OTF2_StringRef sourceFile, uint32_t beginLineNumber,
+                                                      uint32_t endLineNumber);
 
     /** @brief Callback which is triggered by a @ref SystemTreeNode definition record.
      *
@@ -720,17 +698,17 @@ class OTF2Reader : public TraceReader {
      *
      *  @return @eref{OTF2_CALLBACK_SUCCESS} or @eref{OTF2_CALLBACK_INTERRUPT}.
      */
-    static inline OTF2_CallbackCode handle_def_system_tree_node(
-        void* userData, OTF2_SystemTreeNodeRef systemTreeIdentifier, OTF2_StringRef name,
-        OTF2_StringRef className, OTF2_SystemTreeNodeRef parent);
+    static inline OTF2_CallbackCode handle_def_system_tree_node(void*                  userData,
+                                                                OTF2_SystemTreeNodeRef systemTreeIdentifier,
+                                                                OTF2_StringRef name, OTF2_StringRef className,
+                                                                OTF2_SystemTreeNodeRef parent);
 
-    static inline OTF2_CallbackCode handle_def_system_tree_node_property(
-        void* userData, OTF2_SystemTreeNodeRef systemTreeNode, OTF2_StringRef name,
-        OTF2_StringRef value);
+    static inline OTF2_CallbackCode handle_def_system_tree_node_property(void*                  userData,
+                                                                         OTF2_SystemTreeNodeRef systemTreeNode,
+                                                                         OTF2_StringRef name, OTF2_StringRef value);
 
-    static inline OTF2_CallbackCode handle_def_comm(void* userData, OTF2_CommRef self,
-                                                    OTF2_StringRef name, OTF2_GroupRef group,
-                                                    OTF2_CommRef parent);
+    static inline OTF2_CallbackCode handle_def_comm(void* userData, OTF2_CommRef self, OTF2_StringRef name,
+                                                    OTF2_GroupRef group, OTF2_CommRef parent);
 
     /** @brief Callback which is triggered by a Region definition record.
      *
@@ -740,13 +718,10 @@ class OTF2Reader : public TraceReader {
      *
      *  @return @eref{OTF2_CALLBACK_SUCCESS} or @eref{OTF2_CALLBACK_INTERRUPT}.
      */
-    static inline OTF2_CallbackCode handle_def_string(void*          userData,
-                                                      OTF2_StringRef stringIdentifier,
-                                                      const char*    string);
+    static inline OTF2_CallbackCode handle_def_string(void* userData, OTF2_StringRef stringIdentifier,
+                                                      const char* string);
 
-    static inline OTF2_CallbackCode handle_def_paradigm(void*              userData,
-                                                        OTF2_Paradigm      paradigm,
-                                                        OTF2_StringRef     name,
+    static inline OTF2_CallbackCode handle_def_paradigm(void* userData, OTF2_Paradigm paradigm, OTF2_StringRef name,
                                                         OTF2_ParadigmClass paradigmClass);
 };
 #endif /* OTF2_READER_H */

--- a/include/reader/OTFReader.h
+++ b/include/reader/OTFReader.h
@@ -24,7 +24,7 @@ class OTFReader : public TraceReader {
 
    private:
     OTF_FileManager* _manager = nullptr;
-    OTF_Reader* _reader = nullptr;
+    OTF_Reader*      _reader  = nullptr;
 
    private:
     /* *** handlers *** */
@@ -92,8 +92,7 @@ class OTFReader : public TraceReader {
      *  @return                 OTF_RETURN_ABORT  for aborting the reading process immediately
      *                          OTF_RETURN_OK     for continue reading
      */
-    static int handle_def_timerres(void* userData, uint32_t stream, uint64_t ticksPerSecond,
-                                   OTF_KeyValueList* list);
+    static int handle_def_timerres(void* userData, uint32_t stream, uint64_t ticksPerSecond, OTF_KeyValueList* list);
 
     /** @brief Callback function for a process definition record.
      *
@@ -109,8 +108,8 @@ class OTFReader : public TraceReader {
      *  @return             OTF_RETURN_ABORT  for aborting the reading process immediately
      *                      OTF_RETURN_OK     for continue reading
      */
-    static int handle_def_process(void* userData, uint32_t stream, uint32_t process,
-                                  const char* name, uint32_t parent, OTF_KeyValueList* list);
+    static int handle_def_process(void* userData, uint32_t stream, uint32_t process, const char* name, uint32_t parent,
+                                  OTF_KeyValueList* list);
 
     /** @brief Callback function for a process group definition record.
      *
@@ -145,8 +144,8 @@ class OTFReader : public TraceReader {
      *  @return             OTF_RETURN_ABORT  for aborting the reading process immediately
      *                      OTF_RETURN_OK     for continue reading
      */
-    static int handle_def_functiongroup(void* userData, uint32_t stream, uint32_t funcGroup,
-                                        const char* name, OTF_KeyValueList* list);
+    static int handle_def_functiongroup(void* userData, uint32_t stream, uint32_t funcGroup, const char* name,
+                                        OTF_KeyValueList* list);
 
     /** @brief Callback function for a function definition record.
      *
@@ -167,8 +166,8 @@ class OTFReader : public TraceReader {
      *  @return                     OTF_RETURN_ABORT  for aborting the reading process immediately
      *                              OTF_RETURN_OK     for continue reading
      */
-    static int handle_def_function(void* userData, uint32_t stream, uint32_t func, const char* name,
-                                   uint32_t funcGroup, uint32_t source, OTF_KeyValueList* list);
+    static int handle_def_function(void* userData, uint32_t stream, uint32_t func, const char* name, uint32_t funcGroup,
+                                   uint32_t source, OTF_KeyValueList* list);
 
     /** @brief Callback function for a collective operation definition record.
      *
@@ -187,8 +186,8 @@ class OTFReader : public TraceReader {
      *  @return                     OTF_RETURN_ABORT  for aborting the reading process immediately
      *                              OTF_RETURN_OK     for continue reading
      */
-    static int handle_def_collop(void* userData, uint32_t stream, uint32_t collOp, const char* name,
-                                 uint32_t type, OTF_KeyValueList* list);
+    static int handle_def_collop(void* userData, uint32_t stream, uint32_t collOp, const char* name, uint32_t type,
+                                 OTF_KeyValueList* list);
 
     /** @brief Callback function for a counter definition record.
      *
@@ -206,9 +205,8 @@ class OTFReader : public TraceReader {
      *  @return                     OTF_RETURN_ABORT  for aborting the reading process immediately
      *                              OTF_RETURN_OK     for continue reading
      */
-    static int handle_def_counter(void* userData, uint32_t stream, uint32_t counter,
-                                  const char* name, uint32_t properties, uint32_t counterGroup,
-                                  const char* unit, OTF_KeyValueList* list);
+    static int handle_def_counter(void* userData, uint32_t stream, uint32_t counter, const char* name,
+                                  uint32_t properties, uint32_t counterGroup, const char* unit, OTF_KeyValueList* list);
 
     /** @brief Callback function for a KeyValue definition.
      *
@@ -244,8 +242,8 @@ class OTFReader : public TraceReader {
      *  @return                     OTF_RETURN_ABORT  for aborting the reading process immediately
      *                              OTF_RETURN_OK     for continue reading
      */
-    static int handle_enter(void* userData, uint64_t time, uint32_t function, uint32_t process,
-                            uint32_t source, OTF_KeyValueList* list);
+    static int handle_enter(void* userData, uint64_t time, uint32_t function, uint32_t process, uint32_t source,
+                            OTF_KeyValueList* list);
 
     /** @brief Callback function for a function leave event.
      *
@@ -262,8 +260,8 @@ class OTFReader : public TraceReader {
      *  @return                     OTF_RETURN_ABORT  for aborting the reading process immediately
      *                              OTF_RETURN_OK     for continue reading
      */
-    static int handle_leave(void* userData, uint64_t time, uint32_t function, uint32_t process,
-                            uint32_t source, OTF_KeyValueList* list);
+    static int handle_leave(void* userData, uint64_t time, uint32_t function, uint32_t process, uint32_t source,
+                            OTF_KeyValueList* list);
 
     /** @brief Callback function for a counter measurement event.
      *
@@ -278,8 +276,8 @@ class OTFReader : public TraceReader {
      *  @return                     OTF_RETURN_ABORT  for aborting the reading process immediately
      *                              OTF_RETURN_OK     for continue reading
      */
-    static int handle_counter(void* userData, uint64_t time, uint32_t process, uint32_t counter,
-                              uint64_t value, OTF_KeyValueList* list);
+    static int handle_counter(void* userData, uint64_t time, uint32_t process, uint32_t counter, uint64_t value,
+                              OTF_KeyValueList* list);
 
     /** @brief Callback function for a message send event.
      *
@@ -299,9 +297,8 @@ class OTFReader : public TraceReader {
      *  @return                     OTF_RETURN_ABORT  for aborting the reading process immediately
      *                              OTF_RETURN_OK     for continue reading
      */
-    static int handle_send(void* userData, uint64_t time, uint32_t sender, uint32_t receiver,
-                           uint32_t group, uint32_t type, uint32_t length, uint32_t source,
-                           OTF_KeyValueList* list);
+    static int handle_send(void* userData, uint64_t time, uint32_t sender, uint32_t receiver, uint32_t group,
+                           uint32_t type, uint32_t length, uint32_t source, OTF_KeyValueList* list);
 
     /** @brief Callback function for a message send event.
      *
@@ -321,9 +318,8 @@ class OTFReader : public TraceReader {
      *  @return                     OTF_RETURN_ABORT  for aborting the reading process immediately
      *                              OTF_RETURN_OK     for continue reading
      */
-    static int handle_recv(void* userData, uint64_t time, uint32_t recvProc, uint32_t sendProc,
-                           uint32_t group, uint32_t type, uint32_t length, uint32_t source,
-                           OTF_KeyValueList* list);
+    static int handle_recv(void* userData, uint64_t time, uint32_t recvProc, uint32_t sendProc, uint32_t group,
+                           uint32_t type, uint32_t length, uint32_t source, OTF_KeyValueList* list);
 
     /** @brief Callback function for a collective operation member event.
      *
@@ -344,9 +340,8 @@ class OTFReader : public TraceReader {
      *  @return                     OTF_RETURN_ABORT  for aborting the reading process immediately
      *                              OTF_RETURN_OK     for continue reading
      */
-    static int handle_collop(void* userData, uint64_t time, uint32_t process, uint32_t collOp,
-                             uint32_t procGroup, uint32_t rootProc, uint32_t sent,
-                             uint32_t received, uint64_t duration, uint32_t source,
+    static int handle_collop(void* userData, uint64_t time, uint32_t process, uint32_t collOp, uint32_t procGroup,
+                             uint32_t rootProc, uint32_t sent, uint32_t received, uint64_t duration, uint32_t source,
                              OTF_KeyValueList* list);
 
     /** @brief Provides a begin collective operation member event.
@@ -487,10 +482,10 @@ class OTFReader : public TraceReader {
      *  @return Returns OTF_RETURN_ABORT for aborting the reading process immediately,
      *          OTF_RETURN_OK for continue reading.
      */
-        /* TODO nicht verwendet
-    static int handleUnknownRecord(void* userData, uint64_t time, uint32_t process,
-                                   const char* record);
-    */
+    /* TODO nicht verwendet
+static int handleUnknownRecord(void* userData, uint64_t time, uint32_t process,
+                               const char* record);
+*/
 
     /** @brief Callback function for rma put records.
      *

--- a/include/reader/tracereader.h
+++ b/include/reader/tracereader.h
@@ -21,7 +21,7 @@ class TraceReader {
 
 std::unique_ptr<TraceReader> getTraceReader(AllData& alldata);
 
-//data stack for function data -> enter/leave callbacks etc.
+// data stack for function data -> enter/leave callbacks etc.
 struct StackData {
     tree_node* node_p;
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -33,9 +33,7 @@ class TimeMeasurement {
    public:
     TimeMeasurement() = default;
 
-    void registerScope(ScopeID scope_id, std::string desc) {
-        scopes.insert(std::make_pair(scope_id, Scope(desc)));
-    }
+    void registerScope(ScopeID scope_id, std::string desc) { scopes.insert(std::make_pair(scope_id, Scope(desc))); }
 
     bool isRegistered(ScopeID scope_id) {
         if (scopes.find(scope_id) == scopes.end())
@@ -82,8 +80,8 @@ class TimeMeasurement {
             if (scope.start_time == TimePoint() || scope.stop_time == TimePoint())
                 return os;
 
-            os << scope.desc << ": "
-               << std::chrono::duration<double>(scope.stop_time - scope.start_time).count() << "s";
+            os << scope.desc << ": " << std::chrono::duration<double>(scope.stop_time - scope.start_time).count()
+               << "s";
 
             return os;
         }
@@ -94,12 +92,12 @@ class TimeMeasurement {
 };
 
 struct Params {
-    uint32_t    max_file_handles   = 50; //TODO sinn/unsinn?
-    uint32_t    buffer_size        = 1024 * 1024; //TODO sinn/unsinn?
-    //uint32_t    max_groups         = 16;
-    //bool        logaxis            = true;
-    uint8_t     verbose_level      = 0;
-    //bool        read_from_stats    = false;
+    uint32_t max_file_handles = 50;           // TODO sinn/unsinn?
+    uint32_t buffer_size      = 1024 * 1024;  // TODO sinn/unsinn?
+    // uint32_t    max_groups         = 16;
+    // bool        logaxis            = true;
+    uint8_t verbose_level = 0;
+    // bool        read_from_stats    = false;
     bool        read_metrics       = true;  // counter
     bool        create_cube        = false;
     bool        create_json        = false;
@@ -114,12 +112,10 @@ struct Params {
         arguments.assign(argv + 1, argv + argc);
 
         for (auto i = 0; i < arguments.size(); ++i) {
-            if (arguments[i] == "--help" || arguments[i] == "-h")
-            {
+            if (arguments[i] == "--help" || arguments[i] == "-h") {
                 std::cout << std::endl
                           << " " << argv[0] << " - Generates a profile of an OTF or OTF2 trace in CUBE and/or other"
-                          <<  "formats."
-                          << std::endl
+                          << "formats." << std::endl
                           << std::endl
                           << " Syntax: " << argv[0] << " -i <input file name> [options]" << std::endl
                           << std::endl
@@ -135,7 +131,7 @@ struct Params {
                           << "      -f <n>              max. number of filehandles available per rank" << std::endl
                           << "      -i <file>           specify the input tracefile name" << std::endl
                           << "      -nm, --no-metrics   neglect metric events" << std::endl
-                          << "      -o <prefix>         specify the prefix of output file(s)"<< std::endl
+                          << "      -o <prefix>         specify the prefix of output file(s)" << std::endl
                           << "                          (default: result)" << std::endl
                           << "      -v <level>          set verbosity level" << std::endl
                           << "      --version           prints version information" << std::endl;
@@ -149,10 +145,8 @@ struct Params {
                 verbose_level = value;
                 ++i;
             } else if (arguments[i] == "--version") {
-                std::cout << "OTF-Profiler version "
-                          << OTFPROFILER_VERSION_MAJOR << "."
-                          << OTFPROFILER_VERSION_MINOR << "."
-                          << OTFPROFILER_VERSION_PATCH << std::endl;
+                std::cout << "OTF-Profiler version " << OTFPROFILER_VERSION_MAJOR << "." << OTFPROFILER_VERSION_MINOR
+                          << "." << OTFPROFILER_VERSION_PATCH << std::endl;
                 return false;
             } else if (arguments[i] == "--summarize" || arguments[i] == "-s") {
                 summarize_it = true;
@@ -185,14 +179,14 @@ struct Params {
                     return false;
 
                 output_file_prefix = arguments[++i];
-            //TODO testen ob das arg was bringt -- für OTF ist es momentan wichtig da einige counter seg-faults verursachen (nicht strikt synchrone)
-            } else if (arguments[i] == "-nm" || arguments[i] == "--no-metrics" ) {
+                // TODO testen ob das arg was bringt -- für OTF ist es momentan wichtig da einige counter seg-faults
+                // verursachen (nicht strikt synchrone)
+            } else if (arguments[i] == "-nm" || arguments[i] == "--no-metrics") {
                 read_metrics = false;
             }
         }
 
-        if ( input_file_name == "" )
-        {
+        if (input_file_name == "") {
             std::cerr << "ERROR: No input tracefile name given. See --help | -h for further information." << std::endl;
             return false;
         }
@@ -201,7 +195,7 @@ struct Params {
     }
 
    private:
-    //TODO tuts nicht -> -o mitten drin, dann nimmts das nächste
+    // TODO tuts nicht -> -o mitten drin, dann nimmts das nächste
     bool checkNext(std::vector<std::string> args, int pos) {
         if (pos + 1 >= args.size()) {
             std::cerr << "ERROR: Missing argument for option '" << args[pos] << "'" << std::endl;

--- a/src/data_tree.cpp
+++ b/src/data_tree.cpp
@@ -11,25 +11,23 @@ using namespace std;
 
 data_tree::data_tree() {}
 
-//generating a tree out of a mapping sent with MPI - ReduceData - (has no data inside a tree node)
+// generating a tree out of a mapping sent with MPI - ReduceData - (has no data inside a tree node)
 data_tree::data_tree(map<uint64_t, tuple<uint64_t, uint64_t, shared_ptr<tree_node>>>& mapping) {
     shared_ptr<tree_node> tmp_node;
 
     for (auto it = mapping.begin(); it != mapping.end(); it++) {
-
         if (get<1>(it->second) != (uint64_t)-1) {
-            tmp_node =
-                insert_node(get<0>(it->second), get<2>(mapping.find(get<1>(it->second))->second));
+            tmp_node = insert_node(get<0>(it->second), get<2>(mapping.find(get<1>(it->second))->second));
 
         } else {
-            tmp_node = insert_node(get<0>(it->second), (shared_ptr<tree_node>) nullptr);
+            tmp_node = insert_node(get<0>(it->second), (shared_ptr<tree_node>)nullptr);
         }
 
         get<2>(it->second) = tmp_node;
     }
 }
 
-//add a node without data
+// add a node without data
 shared_ptr<tree_node> data_tree::insert_node(uint64_t function_id, shared_ptr<tree_node> parent) {
     if (parent == nullptr) {
         shared_ptr<tree_node> tmp(new tree_node(function_id, parent));
@@ -54,7 +52,7 @@ shared_ptr<tree_node> data_tree::insert_node(uint64_t function_id, shared_ptr<tr
     }
 }
 
-//same as above with different intake and return
+// same as above with different intake and return
 tree_node* data_tree::insert_node(uint64_t function_id, tree_node* parent) {
     if (parent == nullptr) {
         shared_ptr<tree_node> tmp(new tree_node(function_id, parent));
@@ -78,9 +76,8 @@ tree_node* data_tree::insert_node(uint64_t function_id, tree_node* parent) {
     }
 }
 
-//copy a node into the tree - with it's data
+// copy a node into the tree - with it's data
 void data_tree::insert_node(shared_ptr<tree_node> aNode) {
-
     if (aNode->parent == NULL) {
         root_nodes.insert(make_pair(aNode->function_id, aNode));
     } else {
@@ -92,10 +89,9 @@ void data_tree::insert_node(shared_ptr<tree_node> aNode) {
     }
 }
 
-//merge a (temporary) tree into "main" tree
+// merge a (temporary) tree into "main" tree
 void data_tree::merge_tree(data_tree& rhs_tree) {
-
-    for( auto it : rhs_tree.root_nodes ) {
+    for (auto it : rhs_tree.root_nodes) {
         auto lhs_node = root_nodes.find(it.first);
 
         if (lhs_node == root_nodes.end()) {
@@ -107,11 +103,10 @@ void data_tree::merge_tree(data_tree& rhs_tree) {
     }
 }
 
-//merge two nodes -- copying rhs_node's content into lhs's
-//should only be used if one knows that the data inside a node is unique (location wise)
+// merge two nodes -- copying rhs_node's content into lhs's
+// should only be used if one knows that the data inside a node is unique (location wise)
 void data_tree::merge_node(shared_ptr<tree_node>& lhs_node, shared_ptr<tree_node>& rhs_node) {
-
-    for( auto it : rhs_node->node_data ) {
+    for (auto it : rhs_node->node_data) {
         lhs_node->node_data.insert(it);
     }
 
@@ -119,7 +114,7 @@ void data_tree::merge_node(shared_ptr<tree_node>& lhs_node, shared_ptr<tree_node
     lhs_node->have_message.insert(rhs_node->have_message.begin(), rhs_node->have_message.end());
 
     // test for children == children
-    for( auto it : rhs_node->children ) {
+    for (auto it : rhs_node->children) {
         auto lhs_node_o = lhs_node->children.find(it.first);
 
         if (lhs_node_o != lhs_node->children.end()) {
@@ -132,7 +127,7 @@ void data_tree::merge_node(shared_ptr<tree_node>& lhs_node, shared_ptr<tree_node
 
 // TODO zu geringe funktionalität? -> benötigen wir es gesondert?
 void data_tree::insert_sub_tree(shared_ptr<tree_node>& parent, shared_ptr<tree_node>& n_node) {
-    n_node->parent = parent.get();//shared_ptr<tree_node>(parent);
+    n_node->parent = parent.get();  // shared_ptr<tree_node>(parent);
 
     parent->children.insert(make_pair(n_node->function_id, n_node));
 }
@@ -142,15 +137,15 @@ void data_tree::insert_sub_tree(shared_ptr<tree_node>& parent, shared_ptr<tree_n
     ohne die kombinierte funktionalität zu zerfasern
     -> evtl neuimplementation mit iterrator
 */
-//iterate through the tree, generate a mapping and fill the given data deques
-//for communication via MPI
-//only getting called by serialize_data - not intended for usage on it's own
+// iterate through the tree, generate a mapping and fill the given data deques
+// for communication via MPI
+// only getting called by serialize_data - not intended for usage on it's own
 void getting_serial(map<uint64_t, pair<uint64_t, uint64_t>>&         mapping,
                     deque<tuple<uint64_t, uint64_t, FunctionData*>>& f_data,
                     deque<tuple<uint64_t, uint64_t, MessageData*>>&  m_data,
                     deque<tuple<uint64_t, uint64_t, CollopData*>>&   c_data,
-                    deque<tuple<uint64_t, uint64_t, uint64_t, MetricData*>>& met_data,
-                    shared_ptr<tree_node>& aNode, uint64_t& counter, stack<uint64_t>& node_stack) {
+                    deque<tuple<uint64_t, uint64_t, uint64_t, MetricData*>>& met_data, shared_ptr<tree_node>& aNode,
+                    uint64_t& counter, stack<uint64_t>& node_stack) {
     if (!node_stack.empty()) {
         // insert as common node
         mapping.insert(make_pair(counter, make_pair(aNode->function_id, node_stack.top())));
@@ -164,23 +159,20 @@ void getting_serial(map<uint64_t, pair<uint64_t, uint64_t>>&         mapping,
 
     // add all the data \o/
     for (auto it = aNode->node_data.begin(); it != aNode->node_data.end(); ++it) {
-
         f_data.push_back(make_tuple(counter, it->first, &it->second.f_data));
 
-        if( aNode->has_p2p ) {
+        if (aNode->has_p2p) {
             m_data.push_back(make_tuple(counter, it->first, &it->second.m_data));
         }
 
-        if( aNode->has_collop ) {
+        if (aNode->has_collop) {
             c_data.push_back(make_tuple(counter, it->first, &it->second.c_data));
         }
 
-        for (auto it_metric = it->second.metrics.begin(); it_metric != it->second.metrics.end();
-             ++it_metric)
-            met_data.push_back(
-                make_tuple(counter, it->first, it_metric->first, &it_metric->second));
+        for (auto it_metric = it->second.metrics.begin(); it_metric != it->second.metrics.end(); ++it_metric)
+            met_data.push_back(make_tuple(counter, it->first, it_metric->first, &it_metric->second));
     }
-    //counter works as an improvised node id
+    // counter works as an improvised node id
     counter++;
 
     // recursive call
@@ -191,15 +183,15 @@ void getting_serial(map<uint64_t, pair<uint64_t, uint64_t>>&         mapping,
     node_stack.pop();
 }
 
-//function to serialize data for the MPI communication
+// function to serialize data for the MPI communication
 void data_tree::serialize_data(map<uint64_t, pair<uint64_t, uint64_t>>&         mapping,
                                deque<tuple<uint64_t, uint64_t, FunctionData*>>& f_data,
                                deque<tuple<uint64_t, uint64_t, MessageData*>>&  m_data,
                                deque<tuple<uint64_t, uint64_t, CollopData*>>&   c_data,
                                deque<tuple<uint64_t, uint64_t, uint64_t, MetricData*>>& met_data) {
     stack<uint64_t> node_stack;
-    uint64_t counter = 0;  //<- gibt die node_id an die sonst nicht existiert, sie ist für das
-                           //mapping allerdings wichtig -> reduce-Schritt
+    uint64_t        counter = 0;  //<- gibt die node_id an die sonst nicht existiert, sie ist für das
+                                  // mapping allerdings wichtig -> reduce-Schritt
 
     auto it   = root_nodes.begin();
     auto it_e = root_nodes.end();
@@ -210,9 +202,9 @@ void data_tree::serialize_data(map<uint64_t, pair<uint64_t, uint64_t>>&         
 }
 
 tree_iter data_tree::begin() {
-    if( this != nullptr && !root_nodes.empty() ){
+    if (this != nullptr && !root_nodes.empty()) {
         return tree_iter(*this);
-    }else{
+    } else {
         return tree_iter(nullptr, nullptr);
     }
 }
@@ -224,26 +216,41 @@ tree_iter data_tree::end() {
 }
 
 tree_node::tree_node(const uint64_t _function_id, tree_node* _parent)
-    : function_id(_function_id), parent(_parent), last_loc((uint64_t)-1), last_data(nullptr),
-    has_p2p(false), has_collop(false) {}
+    : function_id(_function_id),
+      parent(_parent),
+      last_loc((uint64_t)-1),
+      last_data(nullptr),
+      has_p2p(false),
+      has_collop(false) {}
 
 tree_node::tree_node(const uint64_t _function_id, const shared_ptr<tree_node>& _parent)
-    : function_id(_function_id), parent(_parent.get()), last_loc((uint64_t)-1), last_data(nullptr),
-    has_p2p(false), has_collop(false) {}
+    : function_id(_function_id),
+      parent(_parent.get()),
+      last_loc((uint64_t)-1),
+      last_data(nullptr),
+      has_p2p(false),
+      has_collop(false) {}
 
-tree_node::tree_node(const uint64_t _function_id, const shared_ptr<tree_node>& _parent,
-                     const uint64_t process_num)
-    : function_id(_function_id), parent(_parent.get()), last_loc((uint64_t)-1), last_data(nullptr),
-    has_p2p(false), has_collop(false) {}
+tree_node::tree_node(const uint64_t _function_id, const shared_ptr<tree_node>& _parent, const uint64_t process_num)
+    : function_id(_function_id),
+      parent(_parent.get()),
+      last_loc((uint64_t)-1),
+      last_data(nullptr),
+      has_p2p(false),
+      has_collop(false) {}
 
-tree_node::tree_node( const uint64_t _function_id ) :
-    function_id( _function_id ), parent( nullptr ), last_loc( (uint64_t) -1 ), last_data(nullptr),
-    has_p2p(false), has_collop(false) {}
+tree_node::tree_node(const uint64_t _function_id)
+    : function_id(_function_id),
+      parent(nullptr),
+      last_loc((uint64_t)-1),
+      last_data(nullptr),
+      has_p2p(false),
+      has_collop(false) {}
 
 tree_node::~tree_node() {}
 
-//adding data to call path node and saving the location_id and a pointer to the last used section
-//to speed up repeatedly acces to data of the same location (useful on location/stream wise reading of traces
+// adding data to call path node and saving the location_id and a pointer to the last used section
+// to speed up repeatedly acces to data of the same location (useful on location/stream wise reading of traces
 void tree_node::add_data(const uint64_t location_id, const FunctionData& fdata) {
     if (last_loc == location_id) {
         last_data->f_data += fdata;
@@ -282,7 +289,7 @@ void tree_node::add_data(const uint64_t location_id, const MessageData& mdata) {
     }
 
     have_message.insert(make_pair(location_id, &last_data->m_data));
-//TODO workaround
+    // TODO workaround
     has_p2p = true;
 }
 
@@ -305,12 +312,11 @@ void tree_node::add_data(const uint64_t location_id, const CollopData& cdata) {
     }
 
     have_collop.insert(make_pair(location_id, &last_data->c_data));
-//TODO workaround
+    // TODO workaround
     has_collop = true;
 }
 
-void tree_node::add_data(const uint64_t location_id, const uint64_t metric_id,
-                         const MetricData& metdata) {
+void tree_node::add_data(const uint64_t location_id, const uint64_t metric_id, const MetricData& metdata) {
     if (last_loc != location_id) {
         last_loc = location_id;
 

--- a/src/definitions.cpp
+++ b/src/definitions.cpp
@@ -10,36 +10,34 @@ SystemIterator SystemTree::begin() const { return SystemIterator(root); }
 
 SystemIterator SystemTree::end() const { return SystemIterator(root, nullptr); }
 
-SystemTree* SystemTree::copy_reduced(const SystemTree& sys_tree, uint32_t level ) {
-  auto* n_tree = new SystemTree();
+SystemTree* SystemTree::copy_reduced(const SystemTree& sys_tree, uint32_t level) {
+    auto* n_tree = new SystemTree();
 
-  for( auto it = sys_tree.begin(); it != sys_tree.end(); ++it ) {
+    for (auto it = sys_tree.begin(); it != sys_tree.end(); ++it) {
+        if (level >= it->data.level)
+            n_tree->insert_node(*it);
+        else {
+            auto* parent = it->parent;
+            while (parent->data.level > level)
+                parent = parent->parent;  // TODO parent-ception
 
-    if( level >= it->data.level )
-      n_tree->insert_node( *it );
-    else {
-      auto* parent = it->parent;
-      while( parent->data.level > level)
-        parent = parent->parent; //TODO parent-ception
+            auto parent_loc_id = parent->data.location_id;
+            switch (it->data.class_id) {
+                case SystemClass::LOCATION:
+                    n_tree->locations.insert(
+                        std::make_pair(it->data.location_id, n_tree->location_grps[parent_loc_id]));
+                    break;
+                case definitions::SystemClass::LOCATION_GROUP:
+                    n_tree->location_grps.push_back(n_tree->system_nodes[parent_loc_id]);
+                    break;
 
-      auto parent_loc_id = parent->data.location_id;
-      switch(it->data.class_id) {
-        case SystemClass::LOCATION:
-          n_tree->locations.insert(
-              std::make_pair(it->data.location_id, n_tree->location_grps[parent_loc_id]));
-          break;
-        case definitions::SystemClass::LOCATION_GROUP:
-          n_tree->location_grps.push_back(n_tree->system_nodes[parent_loc_id]);
-          break;
-
-        default:
-          n_tree->system_nodes.push_back(n_tree->system_nodes[parent_loc_id]);
-          break;
-      }
+                default:
+                    n_tree->system_nodes.push_back(n_tree->system_nodes[parent_loc_id]);
+                    break;
+            }
+        }
     }
-  }
 
-  return n_tree;
+    return n_tree;
 }
-
 }

--- a/src/otf-profiler.cpp
+++ b/src/otf-profiler.cpp
@@ -76,8 +76,7 @@ int main(int argc, char** argv) {
     if (reader == nullptr)
         return error();
 
-    if (!reader->initialize(alldata) || !reader->readDefinitions(alldata) ||
-        !reader->readEvents(alldata))
+    if (!reader->initialize(alldata) || !reader->readDefinitions(alldata) || !reader->readEvents(alldata))
         return error();
 
     reader.reset(nullptr);

--- a/src/output/create_cube.cpp
+++ b/src/output/create_cube.cpp
@@ -9,7 +9,7 @@
 #include <Cube.h>
 
 #include "create_cube.h"
-//TODO für tests
+// TODO für tests
 #include <iostream>
 
 using namespace std;
@@ -33,8 +33,8 @@ bool CreateCube(AllData& alldata) {
     map<SystemNode_t*, cube::Process*> MapCubeProcesses;
     map<SystemNode_t*, cube::Thread*>  MapCubeThreads;
 
-    map<uint64_t, cube::Metric*> MapCubeMetrics;
-    map<uint64_t, cube::Region*> MapCubeRegions;
+    map<uint64_t, cube::Metric*>  MapCubeMetrics;
+    map<uint64_t, cube::Region*>  MapCubeRegions;
     map<tree_node*, cube::Cnode*> MapCubeCnodes;
 
     bool have_p2p    = false;
@@ -49,10 +49,10 @@ bool CreateCube(AllData& alldata) {
     // systemtree engage!
     string name, class_name;
 
-    for( auto it = alldata.definitions.system_tree.begin(); it != alldata.definitions.system_tree.end(); ++it ) {
+    for (auto it = alldata.definitions.system_tree.begin(); it != alldata.definitions.system_tree.end(); ++it) {
         auto* node = &(*it);
         auto& data = it->data;
-        switch(it->data.class_id) {
+        switch (it->data.class_id) {
             case definitions::SystemClass::LOCATION:
                 MapCubeThreads[node] = cube_out.def_location(
                     data.name, data.node_id, cube::CUBE_LOCATION_TYPE_CPU_THREAD, MapCubeProcesses[it->parent]);
@@ -62,11 +62,10 @@ bool CreateCube(AllData& alldata) {
                 break;
             case definitions::SystemClass::LOCATION_GROUP:
                 MapCubeProcesses[node] = cube_out.def_location_group(
-                    data.name, data.node_id, cube::CUBE_LOCATION_GROUP_TYPE_PROCESS,
-                    MapCubeNodes[it->parent]);
+                    data.name, data.node_id, cube::CUBE_LOCATION_GROUP_TYPE_PROCESS, MapCubeNodes[it->parent]);
                 break;
             default:
-            MapCubeNodes[node] = cube_out.def_system_tree_node(data.name, "", "node", MapCubeNodes[it->parent]);
+                MapCubeNodes[node] = cube_out.def_system_tree_node(data.name, "", "node", MapCubeNodes[it->parent]);
                 break;
         }
     }
@@ -74,28 +73,26 @@ bool CreateCube(AllData& alldata) {
 
     // cube-metrics engage!
     // implizite annahme dass function_data da ist (IMMER)
-    MapCubeMetrics[0] = cube_out.def_met("Visits", "met_visits", "UINT64", "occ", "", "",
-                                         "display function occurrence for each functiongroup", NULL,
-                                         cube::CUBE_METRIC_EXCLUSIVE);
+    MapCubeMetrics[0] =
+        cube_out.def_met("Visits", "met_visits", "UINT64", "occ", "", "",
+                         "display function occurrence for each functiongroup", NULL, cube::CUBE_METRIC_EXCLUSIVE);
 
-    MapCubeMetrics[1] = cube_out.def_met("Time", "met_time", "DOUBLE", "sec", "", "",
-                                         "display function exclusive time for each functiongroup",
-                                         NULL, cube::CUBE_METRIC_EXCLUSIVE);
+    MapCubeMetrics[1] =
+        cube_out.def_met("Time", "met_time", "DOUBLE", "sec", "", "",
+                         "display function exclusive time for each functiongroup", NULL, cube::CUBE_METRIC_EXCLUSIVE);
 
     string met_visits = "Met_Visits";
     string met_time   = "Met_Time";
 
-    for( const auto& paradigm : alldata.definitions.paradigms.get_all() ) {
+    for (const auto& paradigm : alldata.definitions.paradigms.get_all()) {
         auto c_met_ref =
-            paradigmToCubeMetric_occ.insert(make_pair(paradigm.first, MapCubeMetrics.size()))
-                .first->second;
+            paradigmToCubeMetric_occ.insert(make_pair(paradigm.first, MapCubeMetrics.size())).first->second;
 
         MapCubeMetrics[c_met_ref] =
             cube_out.def_met(paradigm.second.name, paradigm.second.name, "UINT64", "occ", "", "", "",
                              MapCubeMetrics.find(0)->second, cube::CUBE_METRIC_EXCLUSIVE);
 
-        c_met_ref = paradigmToCubeMetric_time.insert(make_pair(paradigm.first, MapCubeMetrics.size()))
-                        .first->second;
+        c_met_ref = paradigmToCubeMetric_time.insert(make_pair(paradigm.first, MapCubeMetrics.size())).first->second;
 
         MapCubeMetrics[c_met_ref] =
             cube_out.def_met(paradigm.second.name, paradigm.second.name, "DOUBLE", "sec", "", "", "",
@@ -103,13 +100,11 @@ bool CreateCube(AllData& alldata) {
     }
 
     if (alldata.params.read_metrics) {
-
         string aType = "";
 
-        for( const auto& metric : alldata.definitions.metrics.get_all() ) {
-            if( metric.second.allowed ) {
-
-                if(metric.second.type == MetricDataType::UINT64) {
+        for (const auto& metric : alldata.definitions.metrics.get_all()) {
+            if (metric.second.allowed) {
+                if (metric.second.type == MetricDataType::UINT64) {
                     aType = "UINT64";
                 } else if (metric.second.type == MetricDataType::DOUBLE) {
                     aType = "DOUBLE";
@@ -117,8 +112,8 @@ bool CreateCube(AllData& alldata) {
                     aType = "INT64";
                 }
 
-                auto c_met_ref = metricToCubeMetric.insert(make_pair(metric.first, MapCubeMetrics.size()))
-                                     .first->second;
+                auto c_met_ref =
+                    metricToCubeMetric.insert(make_pair(metric.first, MapCubeMetrics.size())).first->second;
                 MapCubeMetrics[c_met_ref] =
                     cube_out.def_met(metric.second.name, metric.second.name, aType, metric.second.unit, "", "",
                                      metric.second.description, NULL, cube::CUBE_METRIC_EXCLUSIVE);
@@ -128,22 +123,21 @@ bool CreateCube(AllData& alldata) {
     // cube-metrics end!
 
     // create all the regions
-    for( auto& region : alldata.definitions.regions.get_all() ) {
-        MapCubeRegions[region.first] = cube_out.def_region(
-            region.second.name, region.second.name, "", "", region.second.source_line, 0, "", "", region.second.file_name);
+    for (auto& region : alldata.definitions.regions.get_all()) {
+        MapCubeRegions[region.first] =
+            cube_out.def_region(region.second.name, region.second.name, "", "", region.second.source_line, 0, "", "",
+                                region.second.file_name);
     }
     // stop it!
 
     // create call path nodes -- trricky
     for (auto it = alldata.call_path_tree.begin(); it != alldata.call_path_tree.end(); ++it) {
         if (it->parent != nullptr) {
-            MapCubeCnodes[it.get()] =
-                cube_out.def_cnode(MapCubeRegions.find(it->function_id)->second, "", 0,
-                                   MapCubeCnodes.find(it->parent)->second);
+            MapCubeCnodes[it.get()] = cube_out.def_cnode(MapCubeRegions.find(it->function_id)->second, "", 0,
+                                                         MapCubeCnodes.find(it->parent)->second);
 
         } else {
-            MapCubeCnodes[it.get()] =
-                cube_out.def_cnode(MapCubeRegions.find(it->function_id)->second, "", 0, NULL);
+            MapCubeCnodes[it.get()] = cube_out.def_cnode(MapCubeRegions.find(it->function_id)->second, "", 0, NULL);
         }
 
         if (!have_p2p) {
@@ -151,20 +145,20 @@ bool CreateCube(AllData& alldata) {
                 p2p_start = MapCubeMetrics.size();
 
                 MapCubeMetrics[MapCubeMetrics.size()] =
-                    cube_out.def_met("P2P Communication sent", "met_p2psendcomm", "UINT64", "occ",
-                                     "", "", "", NULL, cube::CUBE_METRIC_EXCLUSIVE);
+                    cube_out.def_met("P2P Communication sent", "met_p2psendcomm", "UINT64", "occ", "", "", "", NULL,
+                                     cube::CUBE_METRIC_EXCLUSIVE);
 
                 MapCubeMetrics[MapCubeMetrics.size()] =
-                    cube_out.def_met("P2P Communication received", "met_p2precvcomm", "UINT64",
-                                     "occ", "", "", "", NULL, cube::CUBE_METRIC_EXCLUSIVE);
+                    cube_out.def_met("P2P Communication received", "met_p2precvcomm", "UINT64", "occ", "", "", "", NULL,
+                                     cube::CUBE_METRIC_EXCLUSIVE);
 
                 MapCubeMetrics[MapCubeMetrics.size()] =
-                    cube_out.def_met("P2P Bytes sent", "met_p2pbytessend", "UINT64", "Bytes", "",
-                                     "", "", NULL, cube::CUBE_METRIC_EXCLUSIVE);
+                    cube_out.def_met("P2P Bytes sent", "met_p2pbytessend", "UINT64", "Bytes", "", "", "", NULL,
+                                     cube::CUBE_METRIC_EXCLUSIVE);
 
                 MapCubeMetrics[MapCubeMetrics.size()] =
-                    cube_out.def_met("P2P Bytes received", "met_p2pbytesrecv", "UINT64", "Bytes",
-                                     "", "", "", NULL, cube::CUBE_METRIC_EXCLUSIVE);
+                    cube_out.def_met("P2P Bytes received", "met_p2pbytesrecv", "UINT64", "Bytes", "", "", "", NULL,
+                                     cube::CUBE_METRIC_EXCLUSIVE);
 
                 have_p2p = true;
             }
@@ -174,27 +168,25 @@ bool CreateCube(AllData& alldata) {
             if (it->has_collop == true) {
                 collop_start = MapCubeMetrics.size();
 
-                MapCubeMetrics[MapCubeMetrics.size()] = cube_out.def_met(
-                    "Collective Communication Bytes sent", "met_collopbytesout", "UINT64", "Bytes",
-                    "", "", "", NULL, cube::CUBE_METRIC_EXCLUSIVE);
-
-                MapCubeMetrics[MapCubeMetrics.size()] = cube_out.def_met(
-                    "Collective Communication Bytes received", "met_collopbytesin", "UINT64",
-                    "Bytes", "", "", "", NULL, cube::CUBE_METRIC_EXCLUSIVE);
+                MapCubeMetrics[MapCubeMetrics.size()] =
+                    cube_out.def_met("Collective Communication Bytes sent", "met_collopbytesout", "UINT64", "Bytes", "",
+                                     "", "", NULL, cube::CUBE_METRIC_EXCLUSIVE);
 
                 MapCubeMetrics[MapCubeMetrics.size()] =
-                    cube_out.def_met("Collective Communication", "met_collopcomm_sum", "UINT64",
-                                     "occ", "", "", "", NULL, cube::CUBE_METRIC_EXCLUSIVE);
+                    cube_out.def_met("Collective Communication Bytes received", "met_collopbytesin", "UINT64", "Bytes",
+                                     "", "", "", NULL, cube::CUBE_METRIC_EXCLUSIVE);
+
+                MapCubeMetrics[MapCubeMetrics.size()] =
+                    cube_out.def_met("Collective Communication", "met_collopcomm_sum", "UINT64", "occ", "", "", "",
+                                     NULL, cube::CUBE_METRIC_EXCLUSIVE);
 
                 MapCubeMetrics[MapCubeMetrics.size()] = cube_out.def_met(
-                    "Collective Communication sent (occ)", "met_collopcomm_send", "UINT64", "occ",
-                    "", "", "", MapCubeMetrics.find(collop_start + 2)->second,
-                    cube::CUBE_METRIC_EXCLUSIVE);
+                    "Collective Communication sent (occ)", "met_collopcomm_send", "UINT64", "occ", "", "", "",
+                    MapCubeMetrics.find(collop_start + 2)->second, cube::CUBE_METRIC_EXCLUSIVE);
 
                 MapCubeMetrics[MapCubeMetrics.size()] = cube_out.def_met(
-                    "Collective Communication received (occ)", "met_collopcomm_recv", "UINT64",
-                    "occ", "", "", "", MapCubeMetrics.find(collop_start + 2)->second,
-                    cube::CUBE_METRIC_EXCLUSIVE);
+                    "Collective Communication received (occ)", "met_collopcomm_recv", "UINT64", "occ", "", "", "",
+                    MapCubeMetrics.find(collop_start + 2)->second, cube::CUBE_METRIC_EXCLUSIVE);
 
                 have_collop = true;
             }
@@ -215,43 +207,38 @@ bool CreateCube(AllData& alldata) {
         cube::Cnode*  tmp_cnode;
         cube::Thread* tmp_thread;
 
-        string   met_string;
-        auto* region = alldata.definitions.regions.get( it->function_id );
-        if(region == nullptr) {
-          std::cerr << "funtion id " << it->function_id << " not found (" << __FILE__
-                    << ":" << __LINE__ << ")";
-          continue;
+        string met_string;
+        auto*  region = alldata.definitions.regions.get(it->function_id);
+        if (region == nullptr) {
+            std::cerr << "funtion id " << it->function_id << " not found (" << __FILE__ << ":" << __LINE__ << ")";
+            continue;
         }
         uint64_t para_id = region->paradigm_id;
-        uint64_t id = 0;
-        tmp_cnode = MapCubeCnodes.find(it.get())->second;
+        uint64_t id      = 0;
+        tmp_cnode        = MapCubeCnodes.find(it.get())->second;
 
-        for( const auto& it_data :it->node_data ) {
+        for (const auto& it_data : it->node_data) {
             auto* location = alldata.definitions.system_tree.location(it_data.first);
-            if(location == nullptr) {
-              cerr << "Cube Output: system location not found: " << it_data.first << endl;
-              continue;
+            if (location == nullptr) {
+                cerr << "Cube Output: system location not found: " << it_data.first << endl;
+                continue;
             }
             tmp_thread = MapCubeThreads.find(location)->second;
 
             // function data
-            cube_out.set_sev(MapCubeMetrics.find(0)->second, tmp_cnode, tmp_thread,
-                             it_data.second.f_data.count);
+            cube_out.set_sev(MapCubeMetrics.find(0)->second, tmp_cnode, tmp_thread, it_data.second.f_data.count);
 
             id = paradigmToCubeMetric_occ.find(para_id)->second;
 
-            cube_out.set_sev(MapCubeMetrics.find(id)->second, tmp_cnode, tmp_thread,
-                             it_data.second.f_data.count);
+            cube_out.set_sev(MapCubeMetrics.find(id)->second, tmp_cnode, tmp_thread, it_data.second.f_data.count);
 
             cube_out.set_sev(MapCubeMetrics.find(1)->second, tmp_cnode, tmp_thread,
-                             (double)it_data.second.f_data.excl_time /
-                                 (double)alldata.metaData.timerResolution);
+                             (double)it_data.second.f_data.excl_time / (double)alldata.metaData.timerResolution);
 
             id = paradigmToCubeMetric_time.find(para_id)->second;
 
             cube_out.set_sev(MapCubeMetrics.find(id)->second, tmp_cnode, tmp_thread,
-                             (double)it_data.second.f_data.excl_time /
-                                 (double)alldata.metaData.timerResolution);
+                             (double)it_data.second.f_data.excl_time / (double)alldata.metaData.timerResolution);
 
             // message data
             if (it_data.second.m_data.count_send > 0) {
@@ -274,8 +261,8 @@ bool CreateCube(AllData& alldata) {
             uint64_t sum = 0;
 
             if (it_data.second.c_data.count_send > 0) {
-                cube_out.set_sev(MapCubeMetrics.find(collop_start + 3)->second, tmp_cnode,
-                                 tmp_thread, it_data.second.c_data.count_send);
+                cube_out.set_sev(MapCubeMetrics.find(collop_start + 3)->second, tmp_cnode, tmp_thread,
+                                 it_data.second.c_data.count_send);
 
                 sum += it_data.second.c_data.count_send;
 
@@ -284,40 +271,32 @@ bool CreateCube(AllData& alldata) {
             }
 
             if (it_data.second.c_data.count_recv > 0) {
-                cube_out.set_sev(MapCubeMetrics.find(collop_start + 4)->second, tmp_cnode,
-                                 tmp_thread, it_data.second.c_data.count_recv);
+                cube_out.set_sev(MapCubeMetrics.find(collop_start + 4)->second, tmp_cnode, tmp_thread,
+                                 it_data.second.c_data.count_recv);
 
                 sum += it_data.second.c_data.count_recv;
 
-                cube_out.set_sev(MapCubeMetrics.find(collop_start + 1)->second, tmp_cnode,
-                                 tmp_thread, it_data.second.c_data.bytes_recv);
+                cube_out.set_sev(MapCubeMetrics.find(collop_start + 1)->second, tmp_cnode, tmp_thread,
+                                 it_data.second.c_data.bytes_recv);
             }
 
-            if( sum > 0 ) {
-
-                cube_out.set_sev(MapCubeMetrics.find(collop_start + 2)->second, tmp_cnode, tmp_thread,
-                             sum);
-
+            if (sum > 0) {
+                cube_out.set_sev(MapCubeMetrics.find(collop_start + 2)->second, tmp_cnode, tmp_thread, sum);
             }
 
             if (!it_data.second.metrics.empty()) {
-
-                for( auto it_met : it_data.second.metrics ) {
-                    auto& metric = it_met.second;
-                    auto* cube_metric =
-                        MapCubeMetrics.find(metricToCubeMetric.find(it_met.first)->second)->second;
+                for (auto it_met : it_data.second.metrics) {
+                    auto& metric      = it_met.second;
+                    auto* cube_metric = MapCubeMetrics.find(metricToCubeMetric.find(it_met.first)->second)->second;
                     switch (metric.type) {
                         case MetricDataType::UINT64:
-                            cube_out.set_sev(cube_metric, tmp_cnode, tmp_thread,
-                                             (uint64_t)metric.data_excl);
+                            cube_out.set_sev(cube_metric, tmp_cnode, tmp_thread, (uint64_t)metric.data_excl);
                             break;
                         case MetricDataType::INT64:
-                            cube_out.set_sev(cube_metric, tmp_cnode, tmp_thread,
-                                             (int64_t)metric.data_excl);
+                            cube_out.set_sev(cube_metric, tmp_cnode, tmp_thread, (int64_t)metric.data_excl);
                             break;
                         case MetricDataType::DOUBLE:
-                            cube_out.set_sev(cube_metric, tmp_cnode, tmp_thread,
-                                             (double)metric.data_excl);
+                            cube_out.set_sev(cube_metric, tmp_cnode, tmp_thread, (double)metric.data_excl);
                             break;
                     }
                 }

--- a/src/output/create_json.cpp
+++ b/src/output/create_json.cpp
@@ -2,184 +2,184 @@
  This is part of the OTF-Profiler. Copyright by ZIH, TU Dresden 2016-2018.
  Authors: Maximillian Neumann, Denis Hünich, Jens Doleschal, Bill Williams
 */
-#include "rapidjson/writer.h"
-#include "rapidjson/stringbuffer.h"
+#include <fstream>
+#include <iostream>
+#include <string>
+#include "all_data.h"
 #include "rapidjson/document.h"
 #include "rapidjson/pointer.h"
 #include "rapidjson/prettywriter.h"
-#include <iostream>
-#include <fstream>
-#include <string>
-#include "all_data.h"
+#include "rapidjson/stringbuffer.h"
+#include "rapidjson/writer.h"
 
 using namespace rapidjson;
 using std::cout;
 using std::string;
 
-
 struct ProfileEntry {
-  std::map<std::string, uint64_t> entries;
-  template <typename Writer>
-  void WriteProfile(Writer& w) const {
-    w.StartObject();
-    for(const auto& kv : entries) {
-      w.Key(StringRef(kv.first.c_str()));
-      w.Uint64(kv.second);
+    std::map<std::string, uint64_t> entries;
+    template <typename Writer>
+    void WriteProfile(Writer& w) const {
+        w.StartObject();
+        for (const auto& kv : entries) {
+            w.Key(StringRef(kv.first.c_str()));
+            w.Uint64(kv.second);
+        }
+        w.EndObject();
     }
-    w.EndObject();
-  }
 };
 
 struct WorkflowProfile {
-  uint64_t job_id;
-  uint32_t node_count;
-  uint32_t process_count;
-  uint32_t thread_count;
-  std::map<std::string, uint64_t> counters;
-  std::map<std::string, ProfileEntry> functions_by_paradigm;
-  std::map<std::string, ProfileEntry> messages_by_paradigm;
-  std::map<std::string, ProfileEntry> collops_by_paradigm;
-  uint64_t parallel_region_time;
-  uint64_t serial_time;
-  uint64_t num_functions;
-  uint64_t num_invocations;
-  template <typename Writer>
-  void WriteProfile(Writer& w) const;
-  WorkflowProfile() :
-    job_id(0),
-    node_count(0),
-    process_count(0),
-    thread_count(0),
-    parallel_region_time(0),
-    serial_time(0),
-    num_functions(0),
-    num_invocations(0)
-  {}
+    uint64_t job_id;
+    uint32_t node_count;
+    uint32_t process_count;
+    uint32_t thread_count;
+    std::map<std::string, uint64_t>     counters;
+    std::map<std::string, ProfileEntry> functions_by_paradigm;
+    std::map<std::string, ProfileEntry> messages_by_paradigm;
+    std::map<std::string, ProfileEntry> collops_by_paradigm;
+    uint64_t parallel_region_time;
+    uint64_t serial_time;
+    uint64_t num_functions;
+    uint64_t num_invocations;
+    template <typename Writer>
+    void WriteProfile(Writer& w) const;
+    WorkflowProfile()
+        : job_id(0),
+          node_count(0),
+          process_count(0),
+          thread_count(0),
+          parallel_region_time(0),
+          serial_time(0),
+          num_functions(0),
+          num_invocations(0) {}
 };
 
 template <typename Map, typename Writer>
 void WriteMapUnderKey(std::string key, const Map& m, Writer& w) {
-  if(m.empty()) return;
-  w.Key(StringRef(key.c_str()));
-  w.StartObject();
-  for(const auto& kv : m) {
-    w.Key(StringRef(kv.first.c_str()));
-    kv.second.WriteProfile(w);
-  }
-  w.EndObject();
+    if (m.empty())
+        return;
+    w.Key(StringRef(key.c_str()));
+    w.StartObject();
+    for (const auto& kv : m) {
+        w.Key(StringRef(kv.first.c_str()));
+        kv.second.WriteProfile(w);
+    }
+    w.EndObject();
 }
 
 template <typename Writer>
-void WorkflowProfile::WriteProfile(Writer& w) const
-{
-  w.StartObject();
-  w.Key("job id");
-  w.Uint64(job_id);
-  w.Key("node count");
-  w.Uint(node_count);
-  w.Key("process count");
-  w.Uint(process_count);
-  w.Key("thread count");
-  w.Uint(thread_count);
-  w.Key("hardware counters");
-  w.StartArray();
-  for(const auto& c : counters) {
-    w.Key(StringRef(c.first.c_str()));
-    w.Uint64(c.second);
-  }
-  w.EndArray();
-  WriteMapUnderKey("functions", functions_by_paradigm, w);
-  WriteMapUnderKey("messages", messages_by_paradigm, w);
-  WriteMapUnderKey("collective operations", collops_by_paradigm, w);
-  w.Key("parallel region time"); w.Uint64(parallel_region_time);
-  w.Key("serial time"); w.Uint64(serial_time);
-  w.Key("total functions"); w.Uint64(num_functions);
-  w.Key("total calls"); w.Uint64(num_invocations);
-  w.EndObject();
+void WorkflowProfile::WriteProfile(Writer& w) const {
+    w.StartObject();
+    w.Key("job id");
+    w.Uint64(job_id);
+    w.Key("node count");
+    w.Uint(node_count);
+    w.Key("process count");
+    w.Uint(process_count);
+    w.Key("thread count");
+    w.Uint(thread_count);
+    w.Key("hardware counters");
+    w.StartArray();
+    for (const auto& c : counters) {
+        w.Key(StringRef(c.first.c_str()));
+        w.Uint64(c.second);
+    }
+    w.EndArray();
+    WriteMapUnderKey("functions", functions_by_paradigm, w);
+    WriteMapUnderKey("messages", messages_by_paradigm, w);
+    WriteMapUnderKey("collective operations", collops_by_paradigm, w);
+    w.Key("parallel region time");
+    w.Uint64(parallel_region_time);
+    w.Key("serial time");
+    w.Uint64(serial_time);
+    w.Key("total functions");
+    w.Uint64(num_functions);
+    w.Key("total calls");
+    w.Uint64(num_invocations);
+    w.EndObject();
 }
 
-
 bool CreateJSON(AllData& alldata) {
+    cout << "Creating JSON profile" << std::endl;
+    WorkflowProfile                 profile;
+    StringBuffer                    b;
+    /*Pretty*/ Writer<StringBuffer> w(b);
+    for (const auto& n : alldata.definitions.system_tree) {
+        switch (n.data.class_id) {
+            case definitions::SystemClass::LOCATION:
+                profile.thread_count++;
+                break;
+            case definitions::SystemClass::LOCATION_GROUP:
+                profile.process_count++;
+                break;
+            case definitions::SystemClass::NODE:
+                profile.node_count++;
+                break;
+            default:
+                break;
+        }
+    }
+    static std::string bytestr("bytes");
+    static std::string timestr("time");
+    static std::string countstr("count");
 
-  cout << "Creating JSON profile" << std::endl;
-  WorkflowProfile profile;
-  StringBuffer b;
-  /*Pretty*/Writer<StringBuffer> w(b);
-  for(const auto& n : alldata.definitions.system_tree) {
-    switch(n.data.class_id) {
-    case definitions::SystemClass::LOCATION:
-      profile.thread_count++;
-      break;
-    case definitions::SystemClass::LOCATION_GROUP:
-      profile.process_count++;
-      break;
-    case definitions::SystemClass::NODE:
-      profile.node_count++;
-      break;
-    default:
-      break;
-    }
-  }
-  static std::string bytestr("bytes");
-  static std::string timestr("time");
-  static std::string countstr("count");
-  
-  for(const auto& call_node : alldata.call_path_tree) {
-    const auto& r = alldata.definitions.regions.get(call_node.function_id);
-    if(!r) {
-      continue;
-    }
+    for (const auto& call_node : alldata.call_path_tree) {
+        const auto& r = alldata.definitions.regions.get(call_node.function_id);
+        if (!r) {
+            continue;
+        }
 
-    const auto& p = alldata.definitions.paradigms.get(r->paradigm_id);
-    std::string paradigm = "Compiler";
-    if(p) {
-      paradigm = p->name;
-    }
+        const auto& p        = alldata.definitions.paradigms.get(r->paradigm_id);
+        std::string paradigm = "Compiler";
+        if (p) {
+            paradigm = p->name;
+        }
 
-    profile.num_functions++;
-    uint64_t excl_time = 0;
-    
-    for(const auto& one_node_data : call_node.node_data) {
-      profile.num_invocations += one_node_data.second.f_data.count;
-      auto& entries_map = profile.functions_by_paradigm[paradigm].entries;
-      entries_map[countstr] += one_node_data.second.f_data.count;
-      if(excl_time < one_node_data.second.f_data.excl_time) {
-	excl_time = one_node_data.second.f_data.excl_time;
-      }
-      if(one_node_data.second.m_data.bytes_send)
-	profile.messages_by_paradigm[paradigm].entries[bytestr] += one_node_data.second.m_data.bytes_send;
-      if(one_node_data.second.m_data.bytes_recv)
-	profile.messages_by_paradigm[paradigm].entries[bytestr] += one_node_data.second.m_data.bytes_recv;
-      if(one_node_data.second.m_data.count_send)
-	profile.messages_by_paradigm[paradigm].entries[countstr] += one_node_data.second.m_data.count_send;
-      if(one_node_data.second.m_data.count_recv)
-	 profile.messages_by_paradigm[paradigm].entries[countstr] += one_node_data.second.m_data.count_recv;
-      if(one_node_data.second.c_data.bytes_send)
-	profile.collops_by_paradigm[paradigm].entries[bytestr] += one_node_data.second.c_data.bytes_send;
-      if(one_node_data.second.c_data.bytes_recv)
-	profile.collops_by_paradigm[paradigm].entries[bytestr] += one_node_data.second.c_data.bytes_recv;
-      if(one_node_data.second.c_data.count_send)
-	profile.collops_by_paradigm[paradigm].entries[countstr] += one_node_data.second.c_data.count_send;
-      if(one_node_data.second.c_data.count_recv)
-	profile.collops_by_paradigm[paradigm].entries[countstr] += one_node_data.second.c_data.count_recv;
-      for(const auto& metric : one_node_data.second.metrics) {
-	if(metric.second.type == MetricDataType::UINT64) {
-	  auto m = alldata.definitions.metrics.get(metric.first);
-	  if(m) profile.counters[m->name] += (uint64_t)metric.second.data_excl;
-	}
-      }
-    }
-    if(call_node.node_data.size() == 1) {
-      profile.serial_time += excl_time;
-    } else {
-      profile.parallel_region_time += excl_time;
-    }
-    profile.functions_by_paradigm[paradigm].entries[timestr] += excl_time;
+        profile.num_functions++;
+        uint64_t excl_time = 0;
 
-  }
-  profile.WriteProfile(w);
-  string fname = alldata.params.output_file_prefix + ".json";
-  std::ofstream outfile(fname.c_str());
-  outfile << b.GetString() << std::endl;
-  return true;
+        for (const auto& one_node_data : call_node.node_data) {
+            profile.num_invocations += one_node_data.second.f_data.count;
+            auto& entries_map = profile.functions_by_paradigm[paradigm].entries;
+            entries_map[countstr] += one_node_data.second.f_data.count;
+            if (excl_time < one_node_data.second.f_data.excl_time) {
+                excl_time = one_node_data.second.f_data.excl_time;
+            }
+            if (one_node_data.second.m_data.bytes_send)
+                profile.messages_by_paradigm[paradigm].entries[bytestr] += one_node_data.second.m_data.bytes_send;
+            if (one_node_data.second.m_data.bytes_recv)
+                profile.messages_by_paradigm[paradigm].entries[bytestr] += one_node_data.second.m_data.bytes_recv;
+            if (one_node_data.second.m_data.count_send)
+                profile.messages_by_paradigm[paradigm].entries[countstr] += one_node_data.second.m_data.count_send;
+            if (one_node_data.second.m_data.count_recv)
+                profile.messages_by_paradigm[paradigm].entries[countstr] += one_node_data.second.m_data.count_recv;
+            if (one_node_data.second.c_data.bytes_send)
+                profile.collops_by_paradigm[paradigm].entries[bytestr] += one_node_data.second.c_data.bytes_send;
+            if (one_node_data.second.c_data.bytes_recv)
+                profile.collops_by_paradigm[paradigm].entries[bytestr] += one_node_data.second.c_data.bytes_recv;
+            if (one_node_data.second.c_data.count_send)
+                profile.collops_by_paradigm[paradigm].entries[countstr] += one_node_data.second.c_data.count_send;
+            if (one_node_data.second.c_data.count_recv)
+                profile.collops_by_paradigm[paradigm].entries[countstr] += one_node_data.second.c_data.count_recv;
+            for (const auto& metric : one_node_data.second.metrics) {
+                if (metric.second.type == MetricDataType::UINT64) {
+                    auto m = alldata.definitions.metrics.get(metric.first);
+                    if (m)
+                        profile.counters[m->name] += (uint64_t)metric.second.data_excl;
+                }
+            }
+        }
+        if (call_node.node_data.size() == 1) {
+            profile.serial_time += excl_time;
+        } else {
+            profile.parallel_region_time += excl_time;
+        }
+        profile.functions_by_paradigm[paradigm].entries[timestr] += excl_time;
+    }
+    profile.WriteProfile(w);
+    string        fname = alldata.params.output_file_prefix + ".json";
+    std::ofstream outfile(fname.c_str());
+    outfile << b.GetString() << std::endl;
+    return true;
 }

--- a/src/output/create_json.cpp
+++ b/src/output/create_json.cpp
@@ -163,9 +163,9 @@ bool CreateJSON(AllData& alldata) {
       if(one_node_data.second.c_data.count_recv)
 	profile.collops_by_paradigm[paradigm].entries[countstr] += one_node_data.second.c_data.count_recv;
       for(const auto& metric : one_node_data.second.metrics) {
-	cout << metric.first << ": " << alldata.metaData.metricIdToName[metric.first] << std::endl;
 	if(metric.second.type == MetricDataType::UINT64) {
-	  profile.counters[alldata.metaData.metricIdToName[metric.first]] += (uint64_t)metric.second.data_excl;
+	  auto m = alldata.definitions.metrics.get(metric.first);
+	  if(m) profile.counters[m->name] += (uint64_t)metric.second.data_excl;
 	}
       }
     }

--- a/src/reader/OTF2Reader.cpp
+++ b/src/reader/OTF2Reader.cpp
@@ -179,7 +179,6 @@ OTF2_CallbackCode OTF2Reader::handle_def_metric_class(void* userData, OTF2_Metri
             }
         }
     }
-
     return OTF2_CALLBACK_SUCCESS;
 }
 
@@ -377,13 +376,12 @@ OTF2_CallbackCode OTF2Reader::handle_metric(OTF2_LocationRef locationID, OTF2_Ti
     auto* alldata = static_cast<AllData*>(userData);
 
     auto class_mapping = alldata->metaData.metricClassToMetric.find(metric);
-
     if (class_mapping != alldata->metaData.metricClassToMetric.end()) {
         MetricDataType a_type;
 
         for (uint8_t i = 0; i < numberOfMetrics; i++) {
             auto metric_ref = class_mapping->second.find(i);
-            auto* metric_def = alldata->definitions.metrics.get(metric_ref->first);
+            auto* metric_def = alldata->definitions.metrics.get(metric_ref->second);
             if (metric_ref != class_mapping->second.end() && metric_def != nullptr &&
                 metric_def->allowed) {
                 MetricData md;
@@ -399,8 +397,10 @@ OTF2_CallbackCode OTF2Reader::handle_metric(OTF2_LocationRef locationID, OTF2_Ti
                           metricValues[i].floating_point};
                 }
 
-                tmp_metric.insert(make_pair(metric_ref->first, md));
-            }
+                tmp_metric.insert(make_pair(metric_ref->second, md));
+            } else {
+	      
+	    }
         }
     }
 

--- a/src/reader/OTFReader.cpp
+++ b/src/reader/OTFReader.cpp
@@ -12,7 +12,7 @@
 #endif
 using namespace std;
 
-static uint64_t systemTreeNodeId = -1;
+static uint64_t              systemTreeNodeId = -1;
 static std::vector<uint64_t> myProcessesList;
 static map<uint64_t, vector<MetricData>> tmp_metric;
 static std::vector<uint64_t> locationList;
@@ -47,8 +47,7 @@ bool OTFReader::initialize(AllData &alldata) {
     /* that's the first access to the input trace file; show tidy error
        message if failed */
     if (0 == test_read) {
-        cerr << "ERROR: Unable to open file '" << alldata.params.input_file_prefix
-             << ".otf' for reading." << endl;
+        cerr << "ERROR: Unable to open file '" << alldata.params.input_file_prefix << ".otf' for reading." << endl;
         OTF_MasterControl_close(master);
         OTF_FileManager_close(manager);
         return false;
@@ -100,30 +99,32 @@ int OTFReader::handle_def_comment(void *fha, uint32_t stream, const char *commen
 }
 */
 
-int OTFReader::handle_def_timerres(void *fha, uint32_t stream, uint64_t ticksPerSecond,
-                                   OTF_KeyValueList *kvlist) {
-    auto* alldata = static_cast<AllData*>(fha);
+int OTFReader::handle_def_timerres(void *fha, uint32_t stream, uint64_t ticksPerSecond, OTF_KeyValueList *kvlist) {
+    auto *alldata = static_cast<AllData *>(fha);
 
     alldata->metaData.timerResolution = ticksPerSecond;
 
     return OTF_RETURN_OK;
 }
 
-int OTFReader::handle_def_process(void *fha, uint32_t stream, uint32_t process, const char *name,
-                                  uint32_t parent, OTF_KeyValueList *kvlist) {
-    auto* alldata = static_cast<AllData*>(fha);
+int OTFReader::handle_def_process(void *fha, uint32_t stream, uint32_t process, const char *name, uint32_t parent,
+                                  OTF_KeyValueList *kvlist) {
+    auto *alldata = static_cast<AllData *>(fha);
 
-    if((alldata->definitions.system_tree).size() == 0){
-        alldata->definitions.system_tree.insert_node("machine", 0, definitions::SystemClass::MACHINE, (uint32_t) -1);
+    if ((alldata->definitions.system_tree).size() == 0) {
+        alldata->definitions.system_tree.insert_node("machine", 0, definitions::SystemClass::MACHINE, (uint32_t)-1);
     }
 
-    if( parent == 0 ) {
+    if (parent == 0) {
         ++systemTreeNodeId;
 
-        alldata->definitions.system_tree.insert_node(name, systemTreeNodeId, definitions::SystemClass::LOCATION_GROUP, 0);
-        alldata->definitions.system_tree.insert_node(name, process, definitions::SystemClass::LOCATION, systemTreeNodeId);
+        alldata->definitions.system_tree.insert_node(name, systemTreeNodeId, definitions::SystemClass::LOCATION_GROUP,
+                                                     0);
+        alldata->definitions.system_tree.insert_node(name, process, definitions::SystemClass::LOCATION,
+                                                     systemTreeNodeId);
     } else {
-        alldata->definitions.system_tree.insert_node(name, process, definitions::SystemClass::LOCATION, systemTreeNodeId);
+        alldata->definitions.system_tree.insert_node(name, process, definitions::SystemClass::LOCATION,
+                                                     systemTreeNodeId);
     }
 
     return OTF_RETURN_OK;
@@ -139,19 +140,18 @@ procs, OTF_KeyValueList* list ) {
 
 }*/
 
-int OTFReader::handle_def_functiongroup(void *fha, uint32_t stream, uint32_t funcGroup,
-                                        const char *name, OTF_KeyValueList *kvlist) {
-    auto* alldata = static_cast<AllData*>(fha);
+int OTFReader::handle_def_functiongroup(void *fha, uint32_t stream, uint32_t funcGroup, const char *name,
+                                        OTF_KeyValueList *kvlist) {
+    auto *alldata = static_cast<AllData *>(fha);
 
     alldata->definitions.groups.add(funcGroup, {name, 0, 0, {}});
 
     return OTF_RETURN_OK;
 }
 
-int OTFReader::handle_def_function(void *fha, uint32_t stream, uint32_t function, const char *name,
-                                   uint32_t funcGroup, uint32_t source, OTF_KeyValueList *kvlist) {
-
-    auto* alldata = static_cast<AllData*>(fha);
+int OTFReader::handle_def_function(void *fha, uint32_t stream, uint32_t function, const char *name, uint32_t funcGroup,
+                                   uint32_t source, OTF_KeyValueList *kvlist) {
+    auto *alldata = static_cast<AllData *>(fha);
     // TODO better solution necessary -> funcGroup is used as pradigm here
     alldata->definitions.regions.add(function, {name, funcGroup, source, ""});
 
@@ -163,10 +163,9 @@ int OTFReader::handle_def_collop(void *fha, uint32_t stream, uint32_t collOp, co
     return OTF_RETURN_OK;
 }
 */
-int OTFReader::handle_def_counter(void *fha, uint32_t stream, uint32_t counter, const char *name,
-                                  uint32_t properties, uint32_t counterGroup, const char *unit,
-                                  OTF_KeyValueList *kvlist) {
-    auto* alldata = static_cast<AllData*>(fha);
+int OTFReader::handle_def_counter(void *fha, uint32_t stream, uint32_t counter, const char *name, uint32_t properties,
+                                  uint32_t counterGroup, const char *unit, OTF_KeyValueList *kvlist) {
+    auto *alldata = static_cast<AllData *>(fha);
 
     if ((properties & OTF_COUNTER_TYPE_ABS) != OTF_COUNTER_TYPE_ABS) {
         if ((properties & OTF_COUNTER_SCOPE_START) == OTF_COUNTER_SCOPE_START) {
@@ -182,8 +181,7 @@ int OTFReader::handle_def_counter(void *fha, uint32_t stream, uint32_t counter, 
                 a_type = MetricDataType::DOUBLE;
             }
 
-            alldata->definitions.metrics.add(counter, {name, "" /*description*/, "" /*unit*/,
-                a_type, true});
+            alldata->definitions.metrics.add(counter, {name, "" /*description*/, "" /*unit*/, a_type, true});
         }
     }
 
@@ -204,20 +202,21 @@ int OTFReader::handle_def_keyvalue(void *fha, uint32_t stream, uint32_t key, OTF
 /*                                                                    */
 /* ****************************************************************** */
 
-int OTFReader::handle_enter(void *fha, uint64_t time, uint32_t function, uint32_t process,
-                            uint32_t source, OTF_KeyValueList *kvlist) {
-    auto* alldata = static_cast<AllData*>(fha);
+int OTFReader::handle_enter(void *fha, uint64_t time, uint32_t function, uint32_t process, uint32_t source,
+                            OTF_KeyValueList *kvlist) {
+    auto *alldata = static_cast<AllData *>(fha);
 
-    tree_node* tmp_node;
-    //explezit kein find benutzt -> subscript operator null-initialisiert wenn nichts vorhanden ist -> sonst gleiches verhalten
-    auto& local_stack = global_node_stack[ process ];
+    tree_node *tmp_node;
+    // explezit kein find benutzt -> subscript operator null-initialisiert wenn nichts vorhanden ist -> sonst gleiches
+    // verhalten
+    auto &local_stack = global_node_stack[process];
 
     if (!local_stack.empty()) {
-        auto tmp = local_stack.front().node_p;
+        auto tmp       = local_stack.front().node_p;
         auto tmp_child = tmp->children.find(function);
 
         if (tmp_child == tmp->children.end()) {
-            tmp_node = alldata->call_path_tree.insert_node((uint64_t) function, tmp);
+            tmp_node = alldata->call_path_tree.insert_node((uint64_t)function, tmp);
         } else {
             tmp_node = tmp_child->second.get();
         }
@@ -225,7 +224,7 @@ int OTFReader::handle_enter(void *fha, uint64_t time, uint32_t function, uint32_
         auto root_node = alldata->call_path_tree.root_nodes.find(function);
 
         if (root_node == alldata->call_path_tree.root_nodes.end()) {
-            tmp_node = alldata->call_path_tree.insert_node((uint64_t) function, nullptr);
+            tmp_node = alldata->call_path_tree.insert_node((uint64_t)function, nullptr);
         } else {
             tmp_node = root_node->second.get();
         }
@@ -237,18 +236,18 @@ int OTFReader::handle_enter(void *fha, uint64_t time, uint32_t function, uint32_
     return OTF_RETURN_OK;
 }
 
-int OTFReader::handle_leave(void *fha, uint64_t time, uint32_t function, uint32_t process,
-                            uint32_t source, OTF_KeyValueList *kvlist) {
-    auto* alldata = static_cast<AllData*>(fha);
+int OTFReader::handle_leave(void *fha, uint64_t time, uint32_t function, uint32_t process, uint32_t source,
+                            OTF_KeyValueList *kvlist) {
+    auto *alldata = static_cast<AllData *>(fha);
 
-    //implizite annahme das sich beim leaver immer min. ein element im stack befindet -> sonst seg. fault
-    auto& local_stack = global_node_stack.find(process)->second;
-    auto& tmp = local_stack.front();
-    uint64_t incl_time = time - tmp.time;
+    // implizite annahme das sich beim leaver immer min. ein element im stack befindet -> sonst seg. fault
+    auto &   local_stack = global_node_stack.find(process)->second;
+    auto &   tmp         = local_stack.front();
+    uint64_t incl_time   = time - tmp.time;
     tmp.node_p->add_data(process, FunctionData{1, incl_time, incl_time - tmp.child_incl});
 
     // metric-counter stuff
-    auto tmp_node(tmp.node_p);
+    auto  tmp_node(tmp.node_p);
     auto &node_metrics = tmp_node->last_data->metrics;
 
     for (auto it = tmp_metric.begin(); it != tmp_metric.end(); ++it) {
@@ -258,17 +257,16 @@ int OTFReader::handle_leave(void *fha, uint64_t time, uint32_t function, uint32_
         auto metric_ref = node_metrics.find(it->first);
 
         if (metric_ref == node_metrics.end()) {
-            metric_ref =
-                node_metrics.insert(make_pair(it->first, MetricData{incl_metric.type})).first;
+            metric_ref = node_metrics.insert(make_pair(it->first, MetricData{incl_metric.type})).first;
         }
 
         metric_ref->second += incl_metric;
         if (tmp_node->parent != nullptr) {
             auto parent_metric_ref = tmp_node->parent->last_data->metrics.find(it->first);
             if (parent_metric_ref == tmp_node->parent->last_data->metrics.end()) {
-                parent_metric_ref = tmp_node->parent->last_data->metrics
-                                        .insert(make_pair(it->first, MetricData{incl_metric.type}))
-                                        .first;
+                parent_metric_ref =
+                    tmp_node->parent->last_data->metrics.insert(make_pair(it->first, MetricData{incl_metric.type}))
+                        .first;
             }
             parent_metric_ref->second.add_incl(incl_metric);
         }
@@ -284,15 +282,15 @@ int OTFReader::handle_leave(void *fha, uint64_t time, uint32_t function, uint32_
     return OTF_RETURN_OK;
 }
 
-int OTFReader::handle_counter(void *fha, uint64_t time, uint32_t process, uint32_t counter,
-                              uint64_t value, OTF_KeyValueList *kvlist) {
-    auto* alldata = static_cast<AllData*>(fha);
+int OTFReader::handle_counter(void *fha, uint64_t time, uint32_t process, uint32_t counter, uint64_t value,
+                              OTF_KeyValueList *kvlist) {
+    auto *alldata = static_cast<AllData *>(fha);
 
-    auto* counter_ref = alldata->definitions.metrics.get(counter);
+    auto *counter_ref = alldata->definitions.metrics.get(counter);
 
     if (counter_ref != nullptr) {
         MetricData md{counter_ref->type, value, value};
-        auto stack_ref = tmp_metric.find(counter);
+        auto       stack_ref = tmp_metric.find(counter);
 
         if (stack_ref == tmp_metric.end()) {
             stack_ref = tmp_metric.insert(make_pair(counter, vector<MetricData>())).first;
@@ -343,41 +341,38 @@ int OTFReader::handle_rma_get(void *fha, uint64_t time, uint32_t process, uint32
     return OTF_RETURN_OK;
 }
 */
-int OTFReader::handle_send(void *fha, uint64_t time, uint32_t sender, uint32_t receiver,
-                           uint32_t group, uint32_t type, uint32_t length, uint32_t source,
-                           OTF_KeyValueList *kvlist) {
-    auto* alldata = static_cast<AllData*>(fha);
+int OTFReader::handle_send(void *fha, uint64_t time, uint32_t sender, uint32_t receiver, uint32_t group, uint32_t type,
+                           uint32_t length, uint32_t source, OTF_KeyValueList *kvlist) {
+    auto *alldata = static_cast<AllData *>(fha);
 
-    auto& tmp = global_node_stack.find(sender)->second.front();
+    auto &tmp = global_node_stack.find(sender)->second.front();
     tmp.node_p->add_data(sender, MessageData{1, 0, length, 0});
 
-//TODO workaround
+    // TODO workaround
     tmp.node_p->has_p2p = true;
 
     return OTF_RETURN_OK;
 }
 
-int OTFReader::handle_recv(void *fha, uint64_t time, uint32_t receiver, uint32_t sender,
-                           uint32_t group, uint32_t type, uint32_t length, uint32_t source,
-                           OTF_KeyValueList *kvlist) {
-    auto* alldata = static_cast<AllData*>(fha);
+int OTFReader::handle_recv(void *fha, uint64_t time, uint32_t receiver, uint32_t sender, uint32_t group, uint32_t type,
+                           uint32_t length, uint32_t source, OTF_KeyValueList *kvlist) {
+    auto *alldata = static_cast<AllData *>(fha);
 
-    auto& tmp = global_node_stack.find(receiver)->second.front();
+    auto &tmp = global_node_stack.find(receiver)->second.front();
     tmp.node_p->add_data(receiver, MessageData{0, 1, 0, length});
 
-//TODO workaround
+    // TODO workaround
     tmp.node_p->has_p2p = true;
 
     return OTF_RETURN_OK;
 }
 
-int OTFReader::handle_collop(void *fha, uint64_t time, uint32_t process, uint32_t collOp,
-                             uint32_t procGroup, uint32_t rootProc, uint32_t sent,
-                             uint32_t received, uint64_t duration, uint32_t source,
+int OTFReader::handle_collop(void *fha, uint64_t time, uint32_t process, uint32_t collOp, uint32_t procGroup,
+                             uint32_t rootProc, uint32_t sent, uint32_t received, uint64_t duration, uint32_t source,
                              OTF_KeyValueList *kvlist) {
-    auto* alldata = static_cast<AllData*>(fha);
+    auto *alldata = static_cast<AllData *>(fha);
 
-    auto& tmp = global_node_stack.find(process)->second.front();
+    auto &tmp = global_node_stack.find(process)->second.front();
 
     if (sent > 0) {
         tmp.node_p->add_data(process, CollopData{1, 0, sent, 0});
@@ -387,7 +382,7 @@ int OTFReader::handle_collop(void *fha, uint64_t time, uint32_t process, uint32_
         tmp.node_p->add_data(process, CollopData{0, 1, 0, received});
     }
 
-//TODO workaround
+    // TODO workaround
     tmp.node_p->has_collop = true;
 
     return OTF_RETURN_OK;
@@ -446,28 +441,21 @@ bool OTFReader::readDefinitions(AllData &alldata) {
     OTF_HandlerArray_setHandler(handlers, (OTF_FunctionPointer *)handle_def_comment,
                                 OTF_DEFINITIONCOMMENT_RECORD);
     */
-    OTF_HandlerArray_setHandler(handlers, (OTF_FunctionPointer *)handle_def_timerres,
-                                OTF_DEFTIMERRESOLUTION_RECORD);
-    OTF_HandlerArray_setHandler(handlers, (OTF_FunctionPointer *)handle_def_process,
-                                OTF_DEFPROCESS_RECORD);
+    OTF_HandlerArray_setHandler(handlers, (OTF_FunctionPointer *)handle_def_timerres, OTF_DEFTIMERRESOLUTION_RECORD);
+    OTF_HandlerArray_setHandler(handlers, (OTF_FunctionPointer *)handle_def_process, OTF_DEFPROCESS_RECORD);
 
     /*TODO    OTF_HandlerArray_setHandler( handlers,
                                     (OTF_FunctionPointer*) handle_def_processgroup,
                                     OTF_DEFPROCESSGROUP_RECORD );
     */
-    OTF_HandlerArray_setHandler(handlers, (OTF_FunctionPointer *)handle_def_function,
-                                OTF_DEFFUNCTION_RECORD);
-    OTF_HandlerArray_setHandler(handlers, (OTF_FunctionPointer *)handle_def_functiongroup,
-                                OTF_DEFFUNCTIONGROUP_RECORD);
+    OTF_HandlerArray_setHandler(handlers, (OTF_FunctionPointer *)handle_def_function, OTF_DEFFUNCTION_RECORD);
+    OTF_HandlerArray_setHandler(handlers, (OTF_FunctionPointer *)handle_def_functiongroup, OTF_DEFFUNCTIONGROUP_RECORD);
     /*TODO nicht verwendet
     OTF_HandlerArray_setHandler(handlers, (OTF_FunctionPointer *)handle_def_collop,
                                 OTF_DEFCOLLOP_RECORD);
     */
-    if( alldata.params.read_metrics ) {
-
-        OTF_HandlerArray_setHandler(handlers, (OTF_FunctionPointer *)handle_def_counter,
-                                    OTF_DEFCOUNTER_RECORD);
-
+    if (alldata.params.read_metrics) {
+        OTF_HandlerArray_setHandler(handlers, (OTF_FunctionPointer *)handle_def_counter, OTF_DEFCOUNTER_RECORD);
     }
 
     /* TODO nicht verwendet
@@ -475,19 +463,17 @@ bool OTFReader::readDefinitions(AllData &alldata) {
                                 OTF_DEFKEYVALUE_RECORD);
     */
     /* set record handler's first arguments */
-    //OTF_HandlerArray_setFirstHandlerArg(handlers, &alldata, OTF_DEFCREATOR_RECORD); TODO nicht verwendet
-    //OTF_HandlerArray_setFirstHandlerArg(handlers, &alldata, OTF_DEFVERSION_RECORD); TODO nicht verwendet
-    //OTF_HandlerArray_setFirstHandlerArg(handlers, &alldata, OTF_DEFINITIONCOMMENT_RECORD); TODO nicht verwendet
+    // OTF_HandlerArray_setFirstHandlerArg(handlers, &alldata, OTF_DEFCREATOR_RECORD); TODO nicht verwendet
+    // OTF_HandlerArray_setFirstHandlerArg(handlers, &alldata, OTF_DEFVERSION_RECORD); TODO nicht verwendet
+    // OTF_HandlerArray_setFirstHandlerArg(handlers, &alldata, OTF_DEFINITIONCOMMENT_RECORD); TODO nicht verwendet
     OTF_HandlerArray_setFirstHandlerArg(handlers, &alldata, OTF_DEFTIMERRESOLUTION_RECORD);
     OTF_HandlerArray_setFirstHandlerArg(handlers, &alldata, OTF_DEFPROCESS_RECORD);
-    //OTF_HandlerArray_setFirstHandlerArg(handlers, &alldata, OTF_DEFPROCESSGROUP_RECORD); TODO nicht verwendet
+    // OTF_HandlerArray_setFirstHandlerArg(handlers, &alldata, OTF_DEFPROCESSGROUP_RECORD); TODO nicht verwendet
     OTF_HandlerArray_setFirstHandlerArg(handlers, &alldata, OTF_DEFFUNCTION_RECORD);
     OTF_HandlerArray_setFirstHandlerArg(handlers, &alldata, OTF_DEFFUNCTIONGROUP_RECORD);
-    //OTF_HandlerArray_setFirstHandlerArg(handlers, &alldata, OTF_DEFCOLLOP_RECORD); TODO nicht verwendet
-    if( alldata.params.read_metrics ) {
-
+    // OTF_HandlerArray_setFirstHandlerArg(handlers, &alldata, OTF_DEFCOLLOP_RECORD); TODO nicht verwendet
+    if (alldata.params.read_metrics) {
         OTF_HandlerArray_setFirstHandlerArg(handlers, &alldata, OTF_DEFCOUNTER_RECORD);
-
     }
 
     OTF_HandlerArray_setFirstHandlerArg(handlers, &alldata, OTF_DEFKEYVALUE_RECORD);
@@ -518,41 +504,40 @@ bool OTFReader::readEvents(AllData &alldata) {
     OTF_HandlerArray_setHandler(handlers, (OTF_FunctionPointer *)handle_enter, OTF_ENTER_RECORD);
     OTF_HandlerArray_setHandler(handlers, (OTF_FunctionPointer *)handle_leave, OTF_LEAVE_RECORD);
 
-    if( alldata.params.read_metrics ) {
-        OTF_HandlerArray_setHandler(handlers, (OTF_FunctionPointer *)handle_counter,
-                                    OTF_COUNTER_RECORD);
+    if (alldata.params.read_metrics) {
+        OTF_HandlerArray_setHandler(handlers, (OTF_FunctionPointer *)handle_counter, OTF_COUNTER_RECORD);
     }
 
     OTF_HandlerArray_setHandler(handlers, (OTF_FunctionPointer *)handle_send, OTF_SEND_RECORD);
     OTF_HandlerArray_setHandler(handlers, (OTF_FunctionPointer *)handle_recv, OTF_RECEIVE_RECORD);
-//    OTF_HandlerArray_setHandler(handlers, (OTF_FunctionPointer *)handle_begin_collop,
-//                                OTF_BEGINCOLLOP_RECORD);
-//    OTF_HandlerArray_setHandler(handlers, (OTF_FunctionPointer *)handle_end_collop,
-//                                OTF_ENDCOLLOP_RECORD);
-    OTF_HandlerArray_setHandler(handlers, (OTF_FunctionPointer *)handle_collop,
-                                OTF_COLLOP_RECORD);
+    //    OTF_HandlerArray_setHandler(handlers, (OTF_FunctionPointer *)handle_begin_collop,
+    //                                OTF_BEGINCOLLOP_RECORD);
+    //    OTF_HandlerArray_setHandler(handlers, (OTF_FunctionPointer *)handle_end_collop,
+    //                                OTF_ENDCOLLOP_RECORD);
+    OTF_HandlerArray_setHandler(handlers, (OTF_FunctionPointer *)handle_collop, OTF_COLLOP_RECORD);
     /*TODO nicht verwendet
-    //OTF_HandlerArray_setHandler(handlers, (OTF_FunctionPointer *)handle_rma_put, OTF_RMAPUT_RECORD); TODO nicht verwendet
-    //OTF_HandlerArray_setHandler(handlers, (OTF_FunctionPointer *)handle_rma_get, OTF_RMAGET_RECORD); TODO nicht verwendet
+    //OTF_HandlerArray_setHandler(handlers, (OTF_FunctionPointer *)handle_rma_put, OTF_RMAPUT_RECORD); TODO nicht
+    verwendet
+    //OTF_HandlerArray_setHandler(handlers, (OTF_FunctionPointer *)handle_rma_get, OTF_RMAGET_RECORD); TODO nicht
+    verwendet
 
     /* set record handler's first arguments */
 
     OTF_HandlerArray_setFirstHandlerArg(handlers, &alldata, OTF_ENTER_RECORD);
     OTF_HandlerArray_setFirstHandlerArg(handlers, &alldata, OTF_LEAVE_RECORD);
 
-    if( alldata.params.read_metrics ) {
+    if (alldata.params.read_metrics) {
         OTF_HandlerArray_setFirstHandlerArg(handlers, &alldata, OTF_COUNTER_RECORD);
-
     }
 
     OTF_HandlerArray_setFirstHandlerArg(handlers, &alldata, OTF_SEND_RECORD);
     OTF_HandlerArray_setFirstHandlerArg(handlers, &alldata, OTF_RECEIVE_RECORD);
-//    OTF_HandlerArray_setFirstHandlerArg(handlers, &alldata, OTF_BEGINCOLLOP_RECORD); TODO nicht verwendet
-//    OTF_HandlerArray_setFirstHandlerArg(handlers, &alldata, OTF_ENDCOLLOP_RECORD); TODO nicht verwendet
+    //    OTF_HandlerArray_setFirstHandlerArg(handlers, &alldata, OTF_BEGINCOLLOP_RECORD); TODO nicht verwendet
+    //    OTF_HandlerArray_setFirstHandlerArg(handlers, &alldata, OTF_ENDCOLLOP_RECORD); TODO nicht verwendet
     OTF_HandlerArray_setFirstHandlerArg(handlers, &alldata, OTF_COLLOP_RECORD);
 
-    //OTF_HandlerArray_setFirstHandlerArg(handlers, &alldata, OTF_RMAPUT_RECORD); TODO nicht verwendet
-    //OTF_HandlerArray_setFirstHandlerArg(handlers, &alldata, OTF_RMAGET_RECORD); TODO nicht verwendet
+    // OTF_HandlerArray_setFirstHandlerArg(handlers, &alldata, OTF_RMAPUT_RECORD); TODO nicht verwendet
+    // OTF_HandlerArray_setFirstHandlerArg(handlers, &alldata, OTF_RMAGET_RECORD); TODO nicht verwendet
 
     /* select processes to read */
     uint64_t records_read = 0;
@@ -568,8 +553,7 @@ bool OTFReader::readEvents(AllData &alldata) {
     uint64_t result;
 
     if (alldata.metaData.myRank == 0) {
-        MPI_Win_allocate(sizeof(uint64_t), sizeof(uint64_t), MPI_INFO_NULL, MPI_COMM_WORLD, &val_p,
-                         &shared_space);
+        MPI_Win_allocate(sizeof(uint64_t), sizeof(uint64_t), MPI_INFO_NULL, MPI_COMM_WORLD, &val_p, &shared_space);
         MPI_Win_lock(MPI_LOCK_EXCLUSIVE, 0, 0, shared_space);
         MPI_Put(&initial, 1, MPI_LONG_LONG_INT, 0, 0, 1, MPI_LONG_LONG_INT, shared_space);
         MPI_Win_unlock(0, shared_space);
@@ -584,8 +568,7 @@ bool OTFReader::readEvents(AllData &alldata) {
         MPI_Compare_and_swap(&to_read, &initial, &result, MPI_LONG_LONG_INT, 0, 0, shared_space);
 
         if (result == initial) {
-            auto areader = OTF_RStream_open(alldata.params.input_file_prefix.c_str(),
-                                            locationList[to_read], _manager);
+            auto areader = OTF_RStream_open(alldata.params.input_file_prefix.c_str(), locationList[to_read], _manager);
 
             if (OTF_RStream_readEvents(areader, handlers) == 0) {
                 return false;
@@ -608,8 +591,7 @@ bool OTFReader::readEvents(AllData &alldata) {
 
     // processes (locations in OTF2) start with 1 rather then 0
     for (uint32_t i = 0; i < locationList.size(); ++i) {
-        auto areader =
-            OTF_RStream_open(alldata.params.input_file_prefix.c_str(), locationList[i], _manager);
+        auto areader = OTF_RStream_open(alldata.params.input_file_prefix.c_str(), locationList[i], _manager);
 
         if (OTF_RStream_readEvents(areader, handlers) == 0) {
             return false;
@@ -621,11 +603,11 @@ bool OTFReader::readEvents(AllData &alldata) {
 
 #endif
     /* Clean up */
-    OTF_HandlerArray_close( handlers );
+    OTF_HandlerArray_close(handlers);
 
     return true;
 }
-//TODO nicht verwendet im moment
+// TODO nicht verwendet im moment
 bool OTFReader::readStatistics(AllData &alldata) {
     bool error = false;
 
@@ -676,4 +658,3 @@ bool OTFReader::readStatistics(AllData &alldata) {
 
     return !error;
 }
-

--- a/src/reader/tracereader.cpp
+++ b/src/reader/tracereader.cpp
@@ -37,8 +37,7 @@ unique_ptr<TraceReader> getTraceReader(AllData& alldata) {
     } else if (filetype == "otf2") {
 #ifndef HAVE_OTF2
         cerr << "ERROR: Can't process OTF2 files!" << endl
-             << "otfprofile was not installed with access to the OTF2 header files/library."
-             << endl;
+             << "otfprofile was not installed with access to the OTF2 header files/library." << endl;
         return nullptr;
 #else
         return unique_ptr<OTF2Reader>(new OTF2Reader);

--- a/src/reduce_data.cpp
+++ b/src/reduce_data.cpp
@@ -3,9 +3,9 @@
  Authors: Maximillian Neumann, Denis Hünich, Jens Doleschal
 */
 
+#include <mpi.h>
 #include <cmath>
 #include <sstream>
-#include <mpi.h>
 
 #include "reduce_data.h"
 
@@ -95,12 +95,9 @@ static char* pack_worker_data(AllData& alldata, uint32_t sizes[PACK_NUM_PACKS]) 
     /* pack mapping (three) */
     {
         for (auto it = mapping.begin(); it != mapping.end(); it++) {
-            MPI_Pack((void*)&it->first, 1, MPI_LONG_LONG_INT, buffer, bytesize, &position,
-                     MPI_COMM_WORLD);
-            MPI_Pack((void*)&it->second.first, 1, MPI_LONG_LONG_INT, buffer, bytesize, &position,
-                     MPI_COMM_WORLD);
-            MPI_Pack((void*)&it->second.second, 1, MPI_LONG_LONG_INT, buffer, bytesize, &position,
-                     MPI_COMM_WORLD);
+            MPI_Pack((void*)&it->first, 1, MPI_LONG_LONG_INT, buffer, bytesize, &position, MPI_COMM_WORLD);
+            MPI_Pack((void*)&it->second.first, 1, MPI_LONG_LONG_INT, buffer, bytesize, &position, MPI_COMM_WORLD);
+            MPI_Pack((void*)&it->second.second, 1, MPI_LONG_LONG_INT, buffer, bytesize, &position, MPI_COMM_WORLD);
         }
     }
 
@@ -111,17 +108,12 @@ static char* pack_worker_data(AllData& alldata, uint32_t sizes[PACK_NUM_PACKS]) 
     {
         for (auto it = f_data.begin(); it != f_data.end(); it++) {
             FunctionData tmp = *get<2>(*it);
-            MPI_Pack((void*)&get<0>(*it), 1, MPI_LONG_LONG_INT, buffer, bytesize, &position,
-                     MPI_COMM_WORLD);
+            MPI_Pack((void*)&get<0>(*it), 1, MPI_LONG_LONG_INT, buffer, bytesize, &position, MPI_COMM_WORLD);
 
-            MPI_Pack((void*)&get<1>(*it), 1, MPI_LONG_LONG_INT, buffer, bytesize, &position,
-                     MPI_COMM_WORLD);
-            MPI_Pack((void*)&tmp.count, 1, MPI_LONG_LONG_INT, buffer, bytesize, &position,
-                     MPI_COMM_WORLD);
-            MPI_Pack((void*)&tmp.incl_time, 1, MPI_LONG_LONG_INT, buffer, bytesize, &position,
-                     MPI_COMM_WORLD);
-            MPI_Pack((void*)&tmp.excl_time, 1, MPI_LONG_LONG_INT, buffer, bytesize, &position,
-                     MPI_COMM_WORLD);
+            MPI_Pack((void*)&get<1>(*it), 1, MPI_LONG_LONG_INT, buffer, bytesize, &position, MPI_COMM_WORLD);
+            MPI_Pack((void*)&tmp.count, 1, MPI_LONG_LONG_INT, buffer, bytesize, &position, MPI_COMM_WORLD);
+            MPI_Pack((void*)&tmp.incl_time, 1, MPI_LONG_LONG_INT, buffer, bytesize, &position, MPI_COMM_WORLD);
+            MPI_Pack((void*)&tmp.excl_time, 1, MPI_LONG_LONG_INT, buffer, bytesize, &position, MPI_COMM_WORLD);
         }
     }
 
@@ -133,19 +125,13 @@ static char* pack_worker_data(AllData& alldata, uint32_t sizes[PACK_NUM_PACKS]) 
         for (auto it = m_data.begin(); it != m_data.end(); it++) {
             MessageData tmp = *get<2>(*it);
 
-            MPI_Pack((void*)&get<0>(*it), 1, MPI_LONG_LONG_INT, buffer, bytesize, &position,
-                     MPI_COMM_WORLD);
+            MPI_Pack((void*)&get<0>(*it), 1, MPI_LONG_LONG_INT, buffer, bytesize, &position, MPI_COMM_WORLD);
 
-            MPI_Pack((void*)&get<1>(*it), 1, MPI_LONG_LONG_INT, buffer, bytesize, &position,
-                     MPI_COMM_WORLD);
-            MPI_Pack((void*)&tmp.count_send, 1, MPI_LONG_LONG_INT, buffer, bytesize, &position,
-                     MPI_COMM_WORLD);
-            MPI_Pack((void*)&tmp.count_recv, 1, MPI_LONG_LONG_INT, buffer, bytesize, &position,
-                     MPI_COMM_WORLD);
-            MPI_Pack((void*)&tmp.bytes_send, 1, MPI_LONG_LONG_INT, buffer, bytesize, &position,
-                     MPI_COMM_WORLD);
-            MPI_Pack((void*)&tmp.bytes_recv, 1, MPI_LONG_LONG_INT, buffer, bytesize, &position,
-                     MPI_COMM_WORLD);
+            MPI_Pack((void*)&get<1>(*it), 1, MPI_LONG_LONG_INT, buffer, bytesize, &position, MPI_COMM_WORLD);
+            MPI_Pack((void*)&tmp.count_send, 1, MPI_LONG_LONG_INT, buffer, bytesize, &position, MPI_COMM_WORLD);
+            MPI_Pack((void*)&tmp.count_recv, 1, MPI_LONG_LONG_INT, buffer, bytesize, &position, MPI_COMM_WORLD);
+            MPI_Pack((void*)&tmp.bytes_send, 1, MPI_LONG_LONG_INT, buffer, bytesize, &position, MPI_COMM_WORLD);
+            MPI_Pack((void*)&tmp.bytes_recv, 1, MPI_LONG_LONG_INT, buffer, bytesize, &position, MPI_COMM_WORLD);
         }
     }
 
@@ -157,19 +143,13 @@ static char* pack_worker_data(AllData& alldata, uint32_t sizes[PACK_NUM_PACKS]) 
         for (auto it = c_data.begin(); it != c_data.end(); it++) {
             CollopData tmp = *get<2>(*it);
 
-            MPI_Pack((void*)&get<0>(*it), 1, MPI_LONG_LONG_INT, buffer, bytesize, &position,
-                     MPI_COMM_WORLD);
-            MPI_Pack((void*)&get<1>(*it), 1, MPI_LONG_LONG_INT, buffer, bytesize, &position,
-                     MPI_COMM_WORLD);
+            MPI_Pack((void*)&get<0>(*it), 1, MPI_LONG_LONG_INT, buffer, bytesize, &position, MPI_COMM_WORLD);
+            MPI_Pack((void*)&get<1>(*it), 1, MPI_LONG_LONG_INT, buffer, bytesize, &position, MPI_COMM_WORLD);
 
-            MPI_Pack((void*)&tmp.count_send, 1, MPI_LONG_LONG_INT, buffer, bytesize, &position,
-                     MPI_COMM_WORLD);
-            MPI_Pack((void*)&tmp.count_recv, 1, MPI_LONG_LONG_INT, buffer, bytesize, &position,
-                     MPI_COMM_WORLD);
-            MPI_Pack((void*)&tmp.bytes_send, 1, MPI_LONG_LONG_INT, buffer, bytesize, &position,
-                     MPI_COMM_WORLD);
-            MPI_Pack((void*)&tmp.bytes_recv, 1, MPI_LONG_LONG_INT, buffer, bytesize, &position,
-                     MPI_COMM_WORLD);
+            MPI_Pack((void*)&tmp.count_send, 1, MPI_LONG_LONG_INT, buffer, bytesize, &position, MPI_COMM_WORLD);
+            MPI_Pack((void*)&tmp.count_recv, 1, MPI_LONG_LONG_INT, buffer, bytesize, &position, MPI_COMM_WORLD);
+            MPI_Pack((void*)&tmp.bytes_send, 1, MPI_LONG_LONG_INT, buffer, bytesize, &position, MPI_COMM_WORLD);
+            MPI_Pack((void*)&tmp.bytes_recv, 1, MPI_LONG_LONG_INT, buffer, bytesize, &position, MPI_COMM_WORLD);
         }
     }
 
@@ -181,34 +161,24 @@ static char* pack_worker_data(AllData& alldata, uint32_t sizes[PACK_NUM_PACKS]) 
         for (auto it = met_data.begin(); it != met_data.end(); it++) {
             MetricData tmp = *get<3>(*it);
 
-            MPI_Pack((void*)&get<0>(*it), 1, MPI_LONG_LONG_INT, buffer, bytesize, &position,
-                     MPI_COMM_WORLD);
-            MPI_Pack((void*)&get<1>(*it), 1, MPI_LONG_LONG_INT, buffer, bytesize, &position,
-                     MPI_COMM_WORLD);
-            MPI_Pack((void*)&get<2>(*it), 1, MPI_LONG_LONG_INT, buffer, bytesize, &position,
-                     MPI_COMM_WORLD);
+            MPI_Pack((void*)&get<0>(*it), 1, MPI_LONG_LONG_INT, buffer, bytesize, &position, MPI_COMM_WORLD);
+            MPI_Pack((void*)&get<1>(*it), 1, MPI_LONG_LONG_INT, buffer, bytesize, &position, MPI_COMM_WORLD);
+            MPI_Pack((void*)&get<2>(*it), 1, MPI_LONG_LONG_INT, buffer, bytesize, &position, MPI_COMM_WORLD);
 
-            MPI_Pack((void*)&tmp.type, 1, MPI_LONG_LONG_INT, buffer, bytesize, &position,
-                     MPI_COMM_WORLD);
+            MPI_Pack((void*)&tmp.type, 1, MPI_LONG_LONG_INT, buffer, bytesize, &position, MPI_COMM_WORLD);
 
             switch (tmp.type) {
                 case MetricDataType::UINT64:
-                    MPI_Pack((void*)&tmp.data_incl, 1, MPI_LONG_LONG_INT, buffer, bytesize,
-                             &position, MPI_COMM_WORLD);
-                    MPI_Pack((void*)&tmp.data_excl, 1, MPI_LONG_LONG_INT, buffer, bytesize,
-                             &position, MPI_COMM_WORLD);
+                    MPI_Pack((void*)&tmp.data_incl, 1, MPI_LONG_LONG_INT, buffer, bytesize, &position, MPI_COMM_WORLD);
+                    MPI_Pack((void*)&tmp.data_excl, 1, MPI_LONG_LONG_INT, buffer, bytesize, &position, MPI_COMM_WORLD);
                     break;
                 case MetricDataType::INT64:
-                    MPI_Pack((void*)&tmp.data_incl, 1, MPI_LONG_LONG_INT, buffer, bytesize,
-                             &position, MPI_COMM_WORLD);
-                    MPI_Pack((void*)&tmp.data_excl, 1, MPI_LONG_LONG_INT, buffer, bytesize,
-                             &position, MPI_COMM_WORLD);
+                    MPI_Pack((void*)&tmp.data_incl, 1, MPI_LONG_LONG_INT, buffer, bytesize, &position, MPI_COMM_WORLD);
+                    MPI_Pack((void*)&tmp.data_excl, 1, MPI_LONG_LONG_INT, buffer, bytesize, &position, MPI_COMM_WORLD);
                     break;
                 case MetricDataType::DOUBLE:
-                    MPI_Pack((void*)&tmp.data_incl, 1, MPI_DOUBLE, buffer, bytesize, &position,
-                             MPI_COMM_WORLD);
-                    MPI_Pack((void*)&tmp.data_excl, 1, MPI_DOUBLE, buffer, bytesize, &position,
-                             MPI_COMM_WORLD);
+                    MPI_Pack((void*)&tmp.data_incl, 1, MPI_DOUBLE, buffer, bytesize, &position, MPI_COMM_WORLD);
+                    MPI_Pack((void*)&tmp.data_excl, 1, MPI_DOUBLE, buffer, bytesize, &position, MPI_COMM_WORLD);
                     break;
             }
         }
@@ -241,8 +211,7 @@ static void unpack_worker_data(AllData& alldata, uint32_t sizes[PACK_NUM_PACKS])
 
     /* extra check that doesn't cost too much */
     fence = 0;
-    MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &fence, 1, MPI_LONG_LONG_INT,
-               MPI_COMM_WORLD);
+    MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &fence, 1, MPI_LONG_LONG_INT, MPI_COMM_WORLD);
     assert(FENCE == fence);
 
     /* unpack mapping -> generate temporary tree */
@@ -250,15 +219,11 @@ static void unpack_worker_data(AllData& alldata, uint32_t sizes[PACK_NUM_PACKS])
         for (uint64_t i = 0; i < sizes[PACK_MAPPING]; i++) {
             uint64_t id, function_id, parent_id;
 
-            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &id, 1, MPI_LONG_LONG_INT,
-                       MPI_COMM_WORLD);
-            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &function_id, 1,
-                       MPI_LONG_LONG_INT, MPI_COMM_WORLD);
-            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &parent_id, 1, MPI_LONG_LONG_INT,
-                       MPI_COMM_WORLD);
+            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &id, 1, MPI_LONG_LONG_INT, MPI_COMM_WORLD);
+            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &function_id, 1, MPI_LONG_LONG_INT, MPI_COMM_WORLD);
+            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &parent_id, 1, MPI_LONG_LONG_INT, MPI_COMM_WORLD);
 
-            tmp_map.insert(
-                make_pair(id, make_tuple(function_id, parent_id, shared_ptr<tree_node>(nullptr))));
+            tmp_map.insert(make_pair(id, make_tuple(function_id, parent_id, shared_ptr<tree_node>(nullptr))));
         }
 
         // generate tree out of mapping AND add pointer to the respective node to the mapping
@@ -266,8 +231,7 @@ static void unpack_worker_data(AllData& alldata, uint32_t sizes[PACK_NUM_PACKS])
 
         /* extra check that doesn't cost too much */
         fence = 0;
-        MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &fence, 1, MPI_LONG_LONG_INT,
-                   MPI_COMM_WORLD);
+        MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &fence, 1, MPI_LONG_LONG_INT, MPI_COMM_WORLD);
         assert(FENCE == fence);
     }
 
@@ -276,17 +240,12 @@ static void unpack_worker_data(AllData& alldata, uint32_t sizes[PACK_NUM_PACKS])
         for (uint64_t i = 0; i < sizes[PACK_FUNCTION_DATA]; i++) {
             uint64_t id, rank, count, incl, excl;
 
-            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &id, 1, MPI_LONG_LONG_INT,
-                       MPI_COMM_WORLD);
+            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &id, 1, MPI_LONG_LONG_INT, MPI_COMM_WORLD);
 
-            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &rank, 1, MPI_LONG_LONG_INT,
-                       MPI_COMM_WORLD);
-            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &count, 1, MPI_LONG_LONG_INT,
-                       MPI_COMM_WORLD);
-            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &incl, 1, MPI_LONG_LONG_INT,
-                       MPI_COMM_WORLD);
-            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &excl, 1, MPI_LONG_LONG_INT,
-                       MPI_COMM_WORLD);
+            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &rank, 1, MPI_LONG_LONG_INT, MPI_COMM_WORLD);
+            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &count, 1, MPI_LONG_LONG_INT, MPI_COMM_WORLD);
+            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &incl, 1, MPI_LONG_LONG_INT, MPI_COMM_WORLD);
+            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &excl, 1, MPI_LONG_LONG_INT, MPI_COMM_WORLD);
 
             /*  IMPORTANT: tmp_map.find( id ) --- find node in mapping
              *  ->second --- get pointer to node in tree
@@ -298,14 +257,12 @@ static void unpack_worker_data(AllData& alldata, uint32_t sizes[PACK_NUM_PACKS])
              *  rank 4-n is safe without testing for the existence of data
              */
 
-            get<2>(tmp_map.find(id)->second)
-                ->node_data.insert(make_pair(rank, FunctionData{count, incl, excl}));
+            get<2>(tmp_map.find(id)->second)->node_data.insert(make_pair(rank, FunctionData{count, incl, excl}));
         }
 
         /* extra check that doesn't cost too much */
         fence = 0;
-        MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &fence, 1, MPI_LONG_LONG_INT,
-                   MPI_COMM_WORLD);
+        MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &fence, 1, MPI_LONG_LONG_INT, MPI_COMM_WORLD);
         assert(FENCE == fence);
     }
 
@@ -314,19 +271,13 @@ static void unpack_worker_data(AllData& alldata, uint32_t sizes[PACK_NUM_PACKS])
         for (uint64_t i = 0; i < sizes[PACK_MESSAGE_DATA]; i++) {
             uint64_t id, rank, count_send, count_recv, bytes_send, bytes_recv;
 
-            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &id, 1, MPI_LONG_LONG_INT,
-                       MPI_COMM_WORLD);
+            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &id, 1, MPI_LONG_LONG_INT, MPI_COMM_WORLD);
 
-            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &rank, 1, MPI_LONG_LONG_INT,
-                       MPI_COMM_WORLD);
-            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &count_send, 1, MPI_LONG_LONG_INT,
-                       MPI_COMM_WORLD);
-            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &count_recv, 1, MPI_LONG_LONG_INT,
-                       MPI_COMM_WORLD);
-            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &bytes_send, 1, MPI_LONG_LONG_INT,
-                       MPI_COMM_WORLD);
-            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &bytes_recv, 1, MPI_LONG_LONG_INT,
-                       MPI_COMM_WORLD);
+            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &rank, 1, MPI_LONG_LONG_INT, MPI_COMM_WORLD);
+            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &count_send, 1, MPI_LONG_LONG_INT, MPI_COMM_WORLD);
+            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &count_recv, 1, MPI_LONG_LONG_INT, MPI_COMM_WORLD);
+            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &bytes_send, 1, MPI_LONG_LONG_INT, MPI_COMM_WORLD);
+            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &bytes_recv, 1, MPI_LONG_LONG_INT, MPI_COMM_WORLD);
 
             // analogous to unpack function data
             get<2>(tmp_map.find(id)->second)
@@ -335,8 +286,7 @@ static void unpack_worker_data(AllData& alldata, uint32_t sizes[PACK_NUM_PACKS])
 
         /* extra check that doesn't cost too much */
         fence = 0;
-        MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &fence, 1, MPI_LONG_LONG_INT,
-                   MPI_COMM_WORLD);
+        MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &fence, 1, MPI_LONG_LONG_INT, MPI_COMM_WORLD);
         assert(FENCE == fence);
     }
 
@@ -345,19 +295,13 @@ static void unpack_worker_data(AllData& alldata, uint32_t sizes[PACK_NUM_PACKS])
         for (uint64_t i = 0; i < sizes[PACK_COLLOP_DATA]; i++) {
             uint64_t id, rank, count_send, count_recv, bytes_send, bytes_recv;
 
-            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &id, 1, MPI_LONG_LONG_INT,
-                       MPI_COMM_WORLD);
+            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &id, 1, MPI_LONG_LONG_INT, MPI_COMM_WORLD);
 
-            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &rank, 1, MPI_LONG_LONG_INT,
-                       MPI_COMM_WORLD);
-            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &count_send, 1, MPI_LONG_LONG_INT,
-                       MPI_COMM_WORLD);
-            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &count_recv, 1, MPI_LONG_LONG_INT,
-                       MPI_COMM_WORLD);
-            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &bytes_send, 1, MPI_LONG_LONG_INT,
-                       MPI_COMM_WORLD);
-            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &bytes_recv, 1, MPI_LONG_LONG_INT,
-                       MPI_COMM_WORLD);
+            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &rank, 1, MPI_LONG_LONG_INT, MPI_COMM_WORLD);
+            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &count_send, 1, MPI_LONG_LONG_INT, MPI_COMM_WORLD);
+            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &count_recv, 1, MPI_LONG_LONG_INT, MPI_COMM_WORLD);
+            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &bytes_send, 1, MPI_LONG_LONG_INT, MPI_COMM_WORLD);
+            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &bytes_recv, 1, MPI_LONG_LONG_INT, MPI_COMM_WORLD);
 
             // analogous to unpack function data
             get<2>(tmp_map.find(id)->second)
@@ -366,8 +310,7 @@ static void unpack_worker_data(AllData& alldata, uint32_t sizes[PACK_NUM_PACKS])
 
         /* extra check that doesn't cost too much */
         fence = 0;
-        MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &fence, 1, MPI_LONG_LONG_INT,
-                   MPI_COMM_WORLD);
+        MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &fence, 1, MPI_LONG_LONG_INT, MPI_COMM_WORLD);
         assert(FENCE == fence);
     }
 
@@ -378,44 +321,38 @@ static void unpack_worker_data(AllData& alldata, uint32_t sizes[PACK_NUM_PACKS])
             uint64_t       id, rank, metric_id;
             MetricDataType type;
 
-            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &id, 1, MPI_LONG_LONG_INT,
-                       MPI_COMM_WORLD);
+            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &id, 1, MPI_LONG_LONG_INT, MPI_COMM_WORLD);
 
-            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &rank, 1, MPI_LONG_LONG_INT,
-                       MPI_COMM_WORLD);
-            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &metric_id, 1, MPI_LONG_LONG_INT,
-                       MPI_COMM_WORLD);
+            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &rank, 1, MPI_LONG_LONG_INT, MPI_COMM_WORLD);
+            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &metric_id, 1, MPI_LONG_LONG_INT, MPI_COMM_WORLD);
 
-            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &type, 1, MPI_LONG_LONG_INT,
-                       MPI_COMM_WORLD);
+            MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &type, 1, MPI_LONG_LONG_INT, MPI_COMM_WORLD);
 
             switch (type) {
                 case MetricDataType::UINT64: {
                     uint64_t value_incl, value_excl;
-                    MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &value_incl, 1,
-                               MPI_LONG_LONG_INT, MPI_COMM_WORLD);
-                    MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &value_excl, 1,
-                               MPI_LONG_LONG_INT, MPI_COMM_WORLD);
+                    MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &value_incl, 1, MPI_LONG_LONG_INT,
+                               MPI_COMM_WORLD);
+                    MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &value_excl, 1, MPI_LONG_LONG_INT,
+                               MPI_COMM_WORLD);
                     get<2>(tmp_map.find(id)->second)
                         ->add_data(rank, metric_id, MetricData{type, value_incl, value_excl});
                     break;
                 }
                 case MetricDataType::DOUBLE: {
                     double value_incl, value_excl;
-                    MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &value_incl, 1,
-                               MPI_DOUBLE, MPI_COMM_WORLD);
-                    MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &value_excl, 1,
-                               MPI_DOUBLE, MPI_COMM_WORLD);
+                    MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &value_incl, 1, MPI_DOUBLE, MPI_COMM_WORLD);
+                    MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &value_excl, 1, MPI_DOUBLE, MPI_COMM_WORLD);
                     get<2>(tmp_map.find(id)->second)
                         ->add_data(rank, metric_id, MetricData{type, value_incl, value_excl});
                     break;
                 }
                 case MetricDataType::INT64: {
                     int64_t value_incl, value_excl;
-                    MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &value_incl, 1,
-                               MPI_LONG_LONG_INT, MPI_COMM_WORLD);
-                    MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &value_excl, 1,
-                               MPI_LONG_LONG_INT, MPI_COMM_WORLD);
+                    MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &value_incl, 1, MPI_LONG_LONG_INT,
+                               MPI_COMM_WORLD);
+                    MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &value_excl, 1, MPI_LONG_LONG_INT,
+                               MPI_COMM_WORLD);
                     get<2>(tmp_map.find(id)->second)
                         ->add_data(rank, metric_id, MetricData{type, value_incl, value_excl});
                     break;
@@ -425,8 +362,7 @@ static void unpack_worker_data(AllData& alldata, uint32_t sizes[PACK_NUM_PACKS])
 
         /* extra check that doesn't cost too much */
         fence = 0;
-        MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &fence, 1, MPI_LONG_LONG_INT,
-                   MPI_COMM_WORLD);
+        MPI_Unpack(buffer, sizes[PACK_TOTAL_SIZE], &position, &fence, 1, MPI_LONG_LONG_INT, MPI_COMM_WORLD);
         assert(FENCE == fence);
     }
 


### PR DESCRIPTION
Metrics in the OTF2Reader were using the wrong index for profile encoding. They should have been added based on their metric ID, but were instead added based on their ordinal in the group of metrics processed in a callback. So we would get a callback for metrics 8, 9, 10 that was encoded as 0, 1, 2, and the results were either discarded or misfiled, depending on what metrics 0, 1, 2 were.

Someone should also look at Cube output and see if the same problem is present.