### PR TITLE
Fixes for I/O events and timestamp resolution

### DIFF
--- a/include/all_data.h
+++ b/include/all_data.h
@@ -26,6 +26,8 @@ struct AllData {
     /* runtime measurement */
     TimeMeasurement tm;
 
+    /* I/O summary */
+    std::map<uint64_t, IoData> io_data;
     AllData(uint32_t my_rank = 0, uint32_t num_ranks = 1) {
         metaData.myRank   = my_rank;
         metaData.numRanks = num_ranks;

--- a/include/data_tree.h
+++ b/include/data_tree.h
@@ -81,7 +81,7 @@ class tree_node {
     std::map<uint64_t, NodeData> node_data;
 
     std::map<uint64_t, MessageData*> have_message;  // TODO raus damit -> sinnlos und fehleranfällig
-    std::map<uint64_t, CollopData*> have_collop;    // TODO raus damit -> sinnlos und fehleranfällig
+    std::map<uint64_t, CollopData*>  have_collop;   // TODO raus damit -> sinnlos und fehleranfällig
     // TODO workaround
     //--->TODO funktion implementieren die aus node_data heraus findet ob collop bzw p2p da ist -> umständlich
     bool has_p2p    = false;

--- a/include/definitions.h
+++ b/include/definitions.h
@@ -320,6 +320,7 @@ struct Definitions {
     DefinitionType<uint64_t, Region>        regions;
     DefinitionType<uint64_t, Metric>        metrics;
     DefinitionType<paradigm_id_t, Paradigm> paradigms;
+    DefinitionType<paradigm_id_t, Paradigm> io_paradigms;
     DefinitionType<uint64_t, IoHandle>      iohandles;
     DefinitionType<uint64_t, Group>         groups;
     SystemTree system_tree{};

--- a/include/definitions.h
+++ b/include/definitions.h
@@ -309,10 +309,18 @@ class SystemIterator {
     std::shared_ptr<SystemNode_t> root_ptr;
 };
 
+struct IoHandle {
+    std::string name;
+    uint32_t    io_paradigm;
+    uint64_t    file;
+    uint64_t    parent;
+};
+
 struct Definitions {
     DefinitionType<uint64_t, Region>        regions;
     DefinitionType<uint64_t, Metric>        metrics;
     DefinitionType<paradigm_id_t, Paradigm> paradigms;
+    DefinitionType<uint64_t, IoHandle>      iohandles;
     DefinitionType<uint64_t, Group>         groups;
     SystemTree system_tree{};
 };

--- a/include/main_structs.h
+++ b/include/main_structs.h
@@ -242,8 +242,8 @@ struct NodeData {
     FunctionData f_data;
     MessageData  m_data;
     CollopData   c_data;
-    std::map<uint64_t, MetricData> metrics;
 
+    std::map<uint64_t, MetricData> metrics;
     NodeData() : f_data(), m_data(), c_data() {}
 
     NodeData(const FunctionData& _f_data) : f_data(_f_data), m_data(), c_data() {}
@@ -251,6 +251,14 @@ struct NodeData {
     NodeData(const MessageData& _m_data) : f_data(), m_data(_m_data), c_data() {}
 
     NodeData(const CollopData& _c_data) : f_data(), m_data(), c_data(_c_data) {}
+};
+
+struct IoData {
+    uint64_t num_operations;
+    uint64_t num_bytes;
+    uint64_t transfer_time;
+    uint64_t nontransfer_time;
+    IoData() : num_operations(0), num_bytes(0), transfer_time(0), nontransfer_time(0) {}
 };
 
 #endif

--- a/include/reader/OTF2Reader.h
+++ b/include/reader/OTF2Reader.h
@@ -9,6 +9,7 @@
 #include <otf2/otf2.h>
 #include "tracereader.h"
 
+template <typename RefT>
 class StringIdentifier {
    public:
     template <typename... Refs>
@@ -17,7 +18,7 @@ class StringIdentifier {
    public:
     StringIdentifier() { string_definitions[OTF2_UNDEFINED_STRING] = ""; }
 
-    void add(OTF2_StringRef ref, const char* string_def) { string_definitions[ref] = string_def; }
+    void add(RefT ref, const char* string_def) { string_definitions[ref] = string_def; }
 
     template <typename... Refs>
     const std::pair<Result_t<Refs...>, OTF2_CallbackCode> get(Refs... refs) {
@@ -38,7 +39,7 @@ class StringIdentifier {
     }
 
    private:
-    std::map<OTF2_StringRef, std::string> string_definitions;
+    std::map<RefT, std::string> string_definitions;
 };
 
 class OTF2Reader : public TraceReader {
@@ -62,6 +63,28 @@ class OTF2Reader : public TraceReader {
     /*                            EVENTS                              */
     /*                                                                */
     /* ************************************************************** */
+
+    static inline OTF2_CallbackCode handle_io_begin(OTF2_LocationRef locationID, OTF2_TimeStamp time,
+                                                    uint64_t eventPosition, void* userData,
+                                                    OTF2_AttributeList* attributeList, OTF2_IoHandleRef handle,
+                                                    OTF2_IoOperationMode mode, OTF2_IoOperationFlag flag,
+                                                    uint64_t bytesRequest, uint64_t matchingId);
+    static inline OTF2_CallbackCode handle_io_end(OTF2_LocationRef locationID, OTF2_TimeStamp time,
+                                                  uint64_t eventPosition, void* userData,
+                                                  OTF2_AttributeList* attributeList, OTF2_IoHandleRef handle,
+                                                  uint64_t bytesResult, uint64_t matchingId);
+    static inline OTF2_CallbackCode handle_def_io_handle(void* userData, OTF2_IoHandleRef self, OTF2_StringRef name,
+                                                         OTF2_IoFileRef file, OTF2_IoParadigmRef ioParadigm,
+                                                         OTF2_IoHandleFlag ioHandleFlags, OTF2_CommRef comm,
+                                                         OTF2_IoHandleRef parent);
+    static inline OTF2_CallbackCode handle_def_io_fs_entry(void* userData, OTF2_IoFileRef self, OTF2_StringRef name,
+                                                           OTF2_SystemTreeNodeRef scope);
+    static inline OTF2_CallbackCode handle_def_io_paradigm(void* userData, OTF2_IoParadigmRef paradigm,
+                                                           OTF2_StringRef id, OTF2_StringRef name,
+                                                           OTF2_IoParadigmClass paradigmClass,
+                                                           OTF2_IoParadigmFlag flags, uint8_t numProperties,
+                                                           const OTF2_IoParadigmProperty* properties,
+                                                           const OTF2_Type* types, const OTF2_AttributeValue* values);
 
     /** @brief Callback for the Enter event record.
      *

--- a/src/reader/OTF2Reader.cpp
+++ b/src/reader/OTF2Reader.cpp
@@ -76,7 +76,11 @@ string OTF2ParadigmToString(OTF2_Paradigm paradigm) {
 
 bool OTF2Reader::initialize(AllData& alldata) {
     alldata.verbosePrint(1, true, "OTF2: reader initalization");
-
+    for(auto para = (int)OTF2_PARADIGM_UNKNOWN;
+	para != (int)OTF2_PARADIGM_SHMEM;
+	++para) {
+      alldata.definitions.paradigms.add(para, {OTF2ParadigmToString(para)});
+    }
     _reader = OTF2_Reader_Open(alldata.params.input_file_name.c_str());
 
     if (nullptr == _reader) {
@@ -122,16 +126,12 @@ OTF2_CallbackCode OTF2Reader::handle_def_io_handle(void* userData, OTF2_IoHandle
         auto strings = filesystem_entries.get(file);
         if (strings.second != OTF2_CALLBACK_SUCCESS)
             return strings.second;
-        cout << "Adding io handle: " << self << ", " << name << " -> " << *strings.first[0] << ", " << file << ", "
-             << parent << endl;
         alldata->definitions.iohandles.add(self, {*strings.first[0], ioParadigm, file, parent});
         return OTF2_CALLBACK_SUCCESS;
     } else {
         auto strings = string_id.get(name);
         if (strings.second != OTF2_CALLBACK_SUCCESS)
             return strings.second;
-        cout << "Adding io handle: " << self << ", " << name << " -> " << *strings.first[0] << ", " << file << ", "
-             << parent << endl;
         alldata->definitions.iohandles.add(self, {*strings.first[0], ioParadigm, file, parent});
     }
     return OTF2_CALLBACK_SUCCESS;
@@ -142,7 +142,6 @@ OTF2_CallbackCode OTF2Reader::handle_def_io_fs_entry(void* userData, OTF2_IoFile
     auto strings = string_id.get(name);
     if (strings.second != OTF2_CALLBACK_SUCCESS)
         return strings.second;
-    cout << "Adding fs entry: " << self << " -> " << name << " -> " << *strings.first[0] << endl;
     filesystem_entries.add(self, strings.first[0]->c_str());
     return OTF2_CALLBACK_SUCCESS;
 }
@@ -398,7 +397,7 @@ OTF2_CallbackCode OTF2Reader::handle_def_io_paradigm(void* userData, OTF2_IoPara
         return strings.second;
     }
 
-    alldata->definitions.paradigms.add(paradigm, {*strings.first[0]});
+    alldata->definitions.io_paradigms.add(paradigm, {*strings.first[0]});
 
     return OTF2_CALLBACK_SUCCESS;
 }
@@ -655,7 +654,7 @@ OTF2_CallbackCode OTF2Reader::handle_mpi_request_test(OTF2_LocationRef locationI
     return OTF2_CALLBACK_SUCCESS;
 }
 */
-/*TODO nicht verwendet
+/*
 OTF2_CallbackCode OTF2Reader::handle_mpi_collective_begin(OTF2_LocationRef locationID,
                                                           OTF2_TimeStamp   time,
                                                           uint64_t eventPosition, void* userData,


### PR DESCRIPTION
We were not correctly reading I/O paradigm definitions and I/O events. These are now read, aggregated, and output by the JSON outputter. We were also not outputting the timestamp resolution. Fixed.